### PR TITLE
Merge master changes into GPU

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,6 +93,7 @@ AC_PROG_F77
 m4_version_prereq([2.70],[], [AC_PROG_CC_C99])
 AS_IF([test "$ac_cv_prog_cc_c99" = "no"], [AC_MSG_ERROR([The compiler does not support C99])])
 AC_PROG_CC_C_O
+AM_PROG_CC_C_O
 AC_PROG_FC
 AC_PROG_FC_C_O
 AC_FC_PP_DEFINE
@@ -137,10 +138,10 @@ case "$with_chameleon" in
       [PKG_CFLAGS="$PKG_CFLAGS $LIBCHAMELEON_CFLAGS"
       PKG_LIBS="$PKG_LIBS $LIBCHAMELEON_LIBS"]
                       ,[
-    
+
       ## something went wrong.
       ## try to find the package without pkg-config
-    
+
       ## check that the library is actually new enough.
       ## by testing for a 1.0.0+ function which we use
       AC_CHECK_LIB(chameleon,CHAMELEON_finalize,[LIBCHAMELEON_LIBS="-lchameleon"])
@@ -205,15 +206,18 @@ case $FC in
       ;;
 
  *nvfortran*)
-      FCFLAGS="$FCFLAGS -fPIC -Mnomain -mp -target=gpu"
+      FCFLAGS="$FCFLAGS -fPIC -Mnomain"
       ;;
 
 esac
 
 case $CC in
 
+  *gcc*)
+        CFLAGS="$CFLAGS -fPIC"
+        ;;
   *nvc*)
-        CFLAGS="$CFLAGS -fPIC -mp -target=gpu"
+        CFLAGS="$CFLAGS -fPIC"
         ;;
 esac
 
@@ -242,26 +246,110 @@ fi
 
 ## Enable GPU offloading
 
-# OpenACC offloading
-AC_ARG_ENABLE(openacc-offload, [AS_HELP_STRING([--openacc-offload],[Use OpenACC-offloaded functions])], HAVE_OPENACC_OFFLOAD=$enableval, HAVE_OPENACC_OFFLOAD=no)
-AS_IF([test "$HAVE_OPENACC_OFFLOAD" = "yes"], [
-   AC_DEFINE([HAVE_OPENACC_OFFLOAD], [1], [If defined, activate OpenACC-offloaded routines])
-   CFLAGS="$OFFLOAD_FLAGS $OFFLOAD_CFLAGS $CFLAGS"
-   FCFLAGS="$OFFLOAD_FLAGS $OFFLOAD_FCFLAGS -DHAVE_OPENACC_OFFLOAD $FCFLAGS"
+# GPU offloading
+AC_ARG_ENABLE(gpu, [AS_HELP_STRING([--enable-gpu],[openmp|openacc : Use GPU-offloaded functions])], enable_gpu=$enableval, enable_gpu=no)
+AS_IF([test "$enable_gpu" = "yes"], [enable_gpu="openmp"])
+
+# OpenMP offloading
+HAVE_OPENMP_OFFLOAD="no"
+AS_IF([test "$enable_gpu" = "openmp"], [
+  AC_DEFINE([HAVE_OPENMP_OFFLOAD], [1], [If defined, activate OpenMP-offloaded routines])
+  HAVE_OPENMP_OFFLOAD="yes"
+  case $CC in
+
+    *gcc*)
+          CFLAGS="$CFLAGS -fopenmp"
+          ;;
+    *nvc*)
+          CFLAGS="$CFLAGS -mp=gpu"
+          ;;
+  esac
+
+  case $FC in
+
+    *gfortran*)
+          FCFLAGS="$FCFLAGS -fopenmp"
+          ;;
+    *nvfortran*)
+          FCFLAGS="$FCFLAGS -mp=gpu"
+          ;;
+  esac]
+)
+
+# OpenMP offloading
+HAVE_OPENACC_OFFLOAD="no"
+AS_IF([test "$enable_gpu" = "openacc"], [
+  AC_DEFINE([HAVE_OPENACC_OFFLOAD], [1], [If defined, activate OpenACC-offloaded routines])
+  HAVE_OPENACC_OFFLOAD="yes"
+  case $CC in
+
+    *gcc*)
+          CFLAGS="$CFLAGS -fopenacc"
+          ;;
+    *nvc*)
+          CFLAGS="$CFLAGS -acc=gpu"
+          ;;
+  esac
+
+  case $FC in
+
+    *gfortran*)
+          FCFLAGS="$FCFLAGS -fopenacc"
+          ;;
+    *nvfortran*)
+          FCFLAGS="$FCFLAGS -acc=gpu"
+          ;;
+  esac
+
 ])
 
 # cuBLAS offloading
-AC_ARG_ENABLE(cublas-offload, [AS_HELP_STRING([--cublas-offload],[Use cuBLAS-offloaded functions])], HAVE_CUBLAS_OFFLOAD=$enableval, HAVE_CUBLAS_OFFLOAD=no)
+AC_ARG_WITH(cublas, [AS_HELP_STRING([--with-cublas],[Use cuBLAS-offloaded functions])], HAVE_CUBLAS_OFFLOAD=$withval, HAVE_CUBLAS_OFFLOAD=no)
 AS_IF([test "$HAVE_CUBLAS_OFFLOAD" = "yes"], [
-   AC_DEFINE([HAVE_CUBLAS_OFFLOAD], [1], [If defined, activate cuBLAS-offloaded routines])
-   FCFLAGS="-DHAVE_CUBLAS_OFFLOAD"
+  AC_DEFINE([HAVE_CUBLAS_OFFLOAD], [1], [If defined, activate cuBLAS-offloaded routines])
+  HAVE_OPENACC_OFFLOAD="yes"
+  case $CC in
+
+    *gcc*)
+          CFLAGS="$CFLAGS -fopenmp"
+          LDFLAGS="-lcublas"
+          ;;
+    *nvc*)
+          CFLAGS="$CFLAGS -mp=gpu -cudalib=cublas"
+          ;;
+  esac
+
+  case $FC in
+
+    *gfortran*)
+          FCFLAGS="$FCFLAGS -fopenmp"
+          ;;
+    *nvfortran*)
+          FCFLAGS="$FCFLAGS -mp=gpu -cudalib=cublas"
+          ;;
+  esac
 ])
 
-# General offload
-AS_IF([test "$HAVE_OPENACC_OFFLOAD" = "yes" || test "$HAVE_CUBLAS_OFFLOAD" = "yes"], [
-   CFLAGS="$OFFLOAD_FLAGS $OFFLOAD_CFLAGS $CFLAGS"
-   FCFLAGS="$OFFLOAD_FLAGS $OFFLOAD_FCFLAGS $FCFLAGS"
-])
+AC_ARG_ENABLE(malloc-trace, [AS_HELP_STRING([--enable-malloc-trace],[use debug malloc/free])], ok=$enableval, ok=no)
+if test "$ok" = "yes"; then
+	AC_DEFINE(MALLOC_TRACE,"malloc_trace.dat",[Define to use debugging malloc/free])
+        ARGS="${ARGS} malloc-trace"
+fi
+
+AC_ARG_ENABLE(prof, [AS_HELP_STRING([--enable-prof],[compile for profiling])], ok=$enableval, ok=no)
+if test "$ok" = "yes"; then
+	CFLAGS="${CFLAGS} -pg"
+	AC_DEFINE(ENABLE_PROF,1,[Define when using the profiler tool])
+        ARGS="${ARGS} prof"
+fi
+
+AC_ARG_WITH(efence, [AS_HELP_STRING([--with-efence],[use ElectricFence library])], ok=$withval, ok=no)
+if test "$ok" = "yes"; then
+	AC_CHECK_LIB([efence], [malloc])
+        ARGS="${ARGS} efence"
+fi
+
+
 
 ##
 
@@ -287,26 +375,6 @@ if test "$ok" = "yes"; then
 	AC_DEFINE(DEBUG,1,[Define to turn on debugging checks])
         ARGS="${ARGS} debug"
 fi
-
-AC_ARG_ENABLE(malloc-trace, [AS_HELP_STRING([--enable-malloc-trace],[use debug malloc/free])], ok=$enableval, ok=no)
-if test "$ok" = "yes"; then
-	AC_DEFINE(MALLOC_TRACE,"malloc_trace.dat",[Define to use debugging malloc/free])
-        ARGS="${ARGS} malloc-trace"
-fi
-
-AC_ARG_ENABLE(prof, [AS_HELP_STRING([--enable-prof],[compile for profiling])], ok=$enableval, ok=no)
-if test "$ok" = "yes"; then
-	CFLAGS="${CFLAGS} -pg"
-	AC_DEFINE(ENABLE_PROF,1,[Define when using the profiler tool])
-        ARGS="${ARGS} prof"
-fi
-
-AC_ARG_WITH(efence, [AS_HELP_STRING([--with-efence],[use ElectricFence library])], ok=$withval, ok=no)
-if test "$ok" = "yes"; then
-	AC_CHECK_LIB(efence, malloc)
-        ARGS="${ARGS} efence"
-fi
-
 
 # Checks for header files.
 
@@ -395,6 +463,7 @@ LDFLAGS:........: ${LDFLAGS}
 LIBS............: ${LIBS}
 USE CHAMELEON...: ${with_chameleon}
 HPC version.....: ${HAVE_HPC}
+OpenMP offload..: ${HAVE_OPENMP_OFFLOAD}
 OpenACC offload.: ${HAVE_OPENACC_OFFLOAD}
 cuBLAS offload..: ${HAVE_CUBLAS_OFFLOAD}
 

--- a/org/qmckl_ao.org
+++ b/org/qmckl_ao.org
@@ -299,6 +299,8 @@ typedef struct qmckl_ao_basis_struct {
   uint64_t           shell_vgl_date;
   double  * restrict ao_vgl;
   uint64_t           ao_vgl_date;
+  double  * restrict ao_value;
+  uint64_t           ao_value_date;
 
   int32_t            uninitialized;
   bool               provided;
@@ -2490,8 +2492,10 @@ free(ao_factor_test);
    | ~primitive_vgl_date~ | ~uint64_t~                        | Last modification date of Value, gradients, Laplacian of the primitives at current positions |
    | ~shell_vgl~          | ~double[point_num][5][shell_num]~ | Value, gradients, Laplacian of the primitives at current  positions                          |
    | ~shell_vgl_date~     | ~uint64_t~                        | Last modification date of Value, gradients, Laplacian of the AOs at current positions        |
-   | ~ao_vgl~             | ~double[point_num][5][ao_num]~    | Value, gradients, Laplacian of the primitives at current  positions                          |
+   | ~ao_vgl~             | ~double[point_num][5][ao_num]~    | Value, gradients, Laplacian of the AOs at current  positions                                 |
    | ~ao_vgl_date~        | ~uint64_t~                        | Last modification date of Value, gradients, Laplacian of the AOs at current positions        |
+   | ~ao_value~           | ~double[point_num][ao_num]~       | Values of the the AOs at current positions                                                   |
+   | ~ao_value_date~      | ~uint64_t~                        | Last modification date of the values of the AOs at current positions                         |
    |----------------------+-----------------------------------+----------------------------------------------------------------------------------------------|
 
 *** After initialization
@@ -3022,7 +3026,7 @@ qmckl_get_ao_basis_ao_vgl (qmckl_context context,
   end interface
     #+end_src
 
-    Uses the give array to compute the VGL.
+    Uses the given array to compute the VGL.
 
     #+begin_src c :comments org :tangle (eval h_func) :noweb yes
 qmckl_exit_code
@@ -3030,7 +3034,7 @@ qmckl_get_ao_basis_ao_vgl_inplace (qmckl_context context,
                                    double* const ao_vgl,
                                    const int64_t size_max);
     #+end_src
-
+    
     #+begin_src c :comments org :tangle (eval c) :noweb yes  :exports none
 qmckl_exit_code
 qmckl_get_ao_basis_ao_vgl_inplace (qmckl_context context,
@@ -3085,6 +3089,133 @@ qmckl_get_ao_basis_ao_vgl_inplace (qmckl_context context,
        double precision,     intent(out)         :: ao_vgl(*)
        integer (c_int64_t) , intent(in)  , value :: size_max
      end function qmckl_get_ao_basis_ao_vgl_inplace
+  end interface
+    #+end_src
+
+
+    
+    #+begin_src c :comments org :tangle (eval h_func) :noweb yes
+qmckl_exit_code
+qmckl_get_ao_basis_ao_value (qmckl_context context,
+                             double* const ao_value,
+                             const int64_t size_max);
+    #+end_src
+
+    Returns the array of values of the atomic orbitals evaluated at
+    the current coordinates. See section [[Combining radial and polynomial parts]].
+
+    #+begin_src c :comments org :tangle (eval c) :noweb yes  :exports none
+qmckl_exit_code
+qmckl_get_ao_basis_ao_value (qmckl_context context,
+                             double* const ao_value,
+                             const int64_t size_max)
+{
+
+  if (qmckl_context_check(context) == QMCKL_NULL_CONTEXT) {
+    return qmckl_failwith( context,
+                           QMCKL_INVALID_CONTEXT,
+                           "qmckl_get_ao_basis_ao_value",
+                           NULL);
+  }
+
+  qmckl_exit_code rc;
+
+  rc = qmckl_provide_ao_value(context);
+  if (rc != QMCKL_SUCCESS) return rc;
+
+  qmckl_context_struct* const ctx = (qmckl_context_struct*) context;
+  assert (ctx != NULL);
+
+  int64_t sze = ctx->ao_basis.ao_num * ctx->point.num;
+  if (size_max < sze) {
+    return qmckl_failwith( context,
+                           QMCKL_INVALID_ARG_3,
+                           "qmckl_get_ao_basis_ao_value",
+                           "input array too small");
+  }
+  memcpy(ao_value, ctx->ao_basis.ao_value, (size_t) sze * sizeof(double));
+
+  return QMCKL_SUCCESS;
+}
+    #+end_src
+
+    #+begin_src f90 :tangle (eval fh_func) :comments org :exports none
+  interface
+     integer(c_int32_t) function qmckl_get_ao_basis_ao_value (context, &
+          ao_value, size_max) bind(C)
+       use, intrinsic :: iso_c_binding
+       import
+       implicit none
+       integer (c_int64_t) , intent(in)  , value :: context
+       double precision,     intent(out)         :: ao_value(*)
+       integer (c_int64_t) , intent(in)  , value :: size_max
+     end function qmckl_get_ao_basis_ao_value
+  end interface
+    #+end_src
+
+    Uses the given array to compute the value.
+
+    #+begin_src c :comments org :tangle (eval h_func) :noweb yes
+qmckl_exit_code
+qmckl_get_ao_basis_ao_value_inplace (qmckl_context context,
+                                     double* const ao_value,
+                                     const int64_t size_max);
+    #+end_src
+    
+    #+begin_src c :comments org :tangle (eval c) :noweb yes  :exports none
+qmckl_exit_code
+qmckl_get_ao_basis_ao_value_inplace (qmckl_context context,
+                                     double* const ao_value,
+                                     const int64_t size_max)
+{
+
+  if (qmckl_context_check(context) == QMCKL_NULL_CONTEXT) {
+    return qmckl_failwith( context,
+                           QMCKL_INVALID_CONTEXT,
+                           "qmckl_get_ao_basis_ao_value",
+                           NULL);
+  }
+
+  qmckl_exit_code rc;
+
+  qmckl_context_struct* const ctx = (qmckl_context_struct*) context;
+  assert (ctx != NULL);
+
+  int64_t sze = ctx->ao_basis.ao_num * ctx->point.num;
+  if (size_max < sze) {
+    return qmckl_failwith( context,
+                           QMCKL_INVALID_ARG_3,
+                           "qmckl_get_ao_basis_ao_value",
+                           "input array too small");
+  }
+
+  rc = qmckl_context_touch(context);
+  if (rc != QMCKL_SUCCESS) return rc;
+
+  double* old_array = ctx->ao_basis.ao_value;
+
+  ctx->ao_basis.ao_value = ao_value;
+
+  rc = qmckl_provide_ao_value(context);
+  if (rc != QMCKL_SUCCESS) return rc;
+
+  ctx->ao_basis.ao_value = old_array;
+
+  return QMCKL_SUCCESS;
+}
+    #+end_src
+
+    #+begin_src f90 :tangle (eval fh_func) :comments org :exports none
+  interface
+     integer(c_int32_t) function qmckl_get_ao_basis_ao_value_inplace (context, &
+          ao_value, size_max) bind(C)
+       use, intrinsic :: iso_c_binding
+       import
+       implicit none
+       integer (c_int64_t) , intent(in)  , value :: context
+       double precision,     intent(out)         :: ao_value(*)
+       integer (c_int64_t) , intent(in)  , value :: size_max
+     end function qmckl_get_ao_basis_ao_value_inplace
   end interface
     #+end_src
 
@@ -4797,7 +4928,7 @@ qmckl_ao_polynomial_transp_vgl_hpc (const qmckl_context context,
                                     const double* restrict X,
                                     const double* restrict R,
                                     const int32_t lmax,
-                                    int64_t* restrict n,
+                                    int64_t* n,
                                     int32_t* restrict const L,
                                     const int64_t ldl,
                                     double* restrict const VGL,
@@ -5285,33 +5416,780 @@ for (int32_t ldl=3 ; ldl<=5 ; ++ldl) {
     #+end_src
 
 * Combining radial and polynomial parts
+
+** Values only
+   :PROPERTIES:
+   :Name:     qmckl_compute_ao_value
+   :CRetType: qmckl_exit_code
+   :FRetType: qmckl_exit_code
+   :END:
+*** Unoptimized version
+     #+NAME: qmckl_ao_value_args_doc
+    | Variable              | Type                              | In/Out | Description                                  |
+    |-----------------------+-----------------------------------+--------+----------------------------------------------|
+    | ~context~             | ~qmckl_context~                   | in     | Global state                                 |
+    | ~ao_num~              | ~int64_t~                         | in     | Number of AOs                                |
+    | ~shell_num~           | ~int64_t~                         | in     | Number of shells                             |
+    | ~point_num~           | ~int64_t~                         | in     | Number of points                             |
+    | ~nucl_num~            | ~int64_t~                         | in     | Number of nuclei                             |
+    | ~coord~               | ~double[3][point_num]~            | in     | Coordinates                                  |
+    | ~nucl_coord~          | ~double[3][nucl_num]~             | in     | Nuclear  coordinates                         |
+    | ~nucleus_index~       | ~int64_t[nucl_num]~               | in     | Index of the 1st shell of each nucleus       |
+    | ~nucleus_shell_num~   | ~int64_t[nucl_num]~               | in     | Number of shells per nucleus                 |
+    | ~nucleus_range~       | ~double[nucl_num]~                | in     | Range beyond which all is zero               |
+    | ~nucleus_max_ang_mom~ | ~int32_t[nucl_num]~               | in     | Maximum angular momentum per nucleus         |
+    | ~shell_ang_mom~       | ~int32_t[shell_num]~              | in     | Angular momentum of each shell               |
+    | ~ao_factor~           | ~double[ao_num]~                  | in     | Normalization factor of the AOs              |
+    | ~shell_vgl~           | ~double[point_num][5][shell_num]~ | in     | Value, gradients and Laplacian of the shells |
+    | ~ao_value~            | ~double[point_num][ao_num]~       | out    | Values of the AOs                            |
+
+     #+begin_src f90 :comments org :tangle (eval f) :noweb yes
+integer function qmckl_compute_ao_value_doc_f(context, &
+     ao_num, shell_num, point_num, nucl_num, &
+     coord, nucl_coord, nucleus_index, nucleus_shell_num, &
+     nucleus_range, nucleus_max_ang_mom, shell_ang_mom, &
+     ao_factor, shell_vgl, ao_value) &
+     result(info)
+  use qmckl
+  implicit none
+  integer(qmckl_context), intent(in)  :: context
+  integer*8             , intent(in)  :: ao_num
+  integer*8             , intent(in)  :: shell_num
+  integer*8             , intent(in)  :: point_num
+  integer*8             , intent(in)  :: nucl_num
+  double precision      , intent(in)  :: coord(point_num,3)
+  double precision      , intent(in)  :: nucl_coord(nucl_num,3)
+  integer*8             , intent(in)  :: nucleus_index(nucl_num)
+  integer*8             , intent(in)  :: nucleus_shell_num(nucl_num)
+  double precision      , intent(in)  :: nucleus_range(nucl_num)
+  integer               , intent(in)  :: nucleus_max_ang_mom(nucl_num)
+  integer               , intent(in)  :: shell_ang_mom(shell_num)
+  double precision      , intent(in)  :: ao_factor(ao_num)
+  double precision      , intent(in)  :: shell_vgl(shell_num,5,point_num)
+  double precision      , intent(out) :: ao_value(ao_num,point_num)
+
+  double precision  :: e_coord(3), n_coord(3)
+  integer*8         :: n_poly
+  integer           :: l, il, k
+  integer*8         :: ipoint, inucl, ishell
+  integer*8         :: ishell_start, ishell_end
+  integer           :: lstart(0:20)
+  double precision  :: x, y, z, r2
+  double precision  :: cutoff
+  integer, external :: qmckl_ao_polynomial_vgl_doc_f
+
+  double precision, allocatable  :: poly_vgl(:,:)
+  integer         , allocatable  :: powers(:,:), ao_index(:)
+
+  allocate(poly_vgl(5,ao_num), powers(3,ao_num), ao_index(ao_num))
+
+  ! Pre-computed data
+  do l=0,20
+     lstart(l) = l*(l+1)*(l+2)/6 +1
+  end do
+
+  k=1
+  do inucl=1,nucl_num
+     ishell_start = nucleus_index(inucl) + 1
+     ishell_end   = nucleus_index(inucl) + nucleus_shell_num(inucl)
+     do ishell = ishell_start, ishell_end
+        l = shell_ang_mom(ishell)
+        ao_index(ishell) = k
+        k = k + lstart(l+1) - lstart(l)
+     end do
+  end do
+  info = QMCKL_SUCCESS
+
+  ! Don't compute polynomials when the radial part is zero.
+  cutoff = -dlog(1.d-12)
+
+  do ipoint = 1, point_num
+     e_coord(1) = coord(ipoint,1)
+     e_coord(2) = coord(ipoint,2)
+     e_coord(3) = coord(ipoint,3)
+     do inucl=1,nucl_num
+        n_coord(1) = nucl_coord(inucl,1)
+        n_coord(2) = nucl_coord(inucl,2)
+        n_coord(3) = nucl_coord(inucl,3)
+
+        ! Test if the point is in the range of the nucleus
+        x = e_coord(1) - n_coord(1)
+        y = e_coord(2) - n_coord(2)
+        z = e_coord(3) - n_coord(3)
+
+        r2 = x*x + y*y + z*z
+
+        if (r2 > cutoff*nucleus_range(inucl)) then
+           cycle
+        end if
+
+        ! Compute polynomials
+        info = qmckl_ao_polynomial_vgl_doc_f(context, e_coord, n_coord, &
+             nucleus_max_ang_mom(inucl), n_poly, powers, 3_8, &
+             poly_vgl, 5_8)
+
+        ! Loop over shells
+        ishell_start = nucleus_index(inucl) + 1
+        ishell_end   = nucleus_index(inucl) + nucleus_shell_num(inucl)
+        do ishell = ishell_start, ishell_end
+           k = ao_index(ishell)
+           l = shell_ang_mom(ishell)
+           do il = lstart(l), lstart(l+1)-1
+              ! Value
+              ao_value(k,ipoint) = &
+                   poly_vgl(1,il) * shell_vgl(ishell,1,ipoint) * ao_factor(k)
+              k = k+1
+           end do
+        end do
+     end do
+  end do
+
+  deallocate(poly_vgl, powers)
+end function qmckl_compute_ao_value_doc_f
+     #+end_src
+
+*** HPC version
+     #+NAME: qmckl_ao_value_args_hpc_gaussian
+    | Variable              | Type                        | In/Out | Description                                  |
+    |-----------------------+-----------------------------+--------+----------------------------------------------|
+    | ~context~             | ~qmckl_context~             | in     | Global state                                 |
+    | ~ao_num~              | ~int64_t~                   | in     | Number of AOs                                |
+    | ~shell_num~           | ~int64_t~                   | in     | Number of shells                             |
+    | ~prim_num~            | ~int64_t~                   | in     | Number of primitives                         |
+    | ~point_num~           | ~int64_t~                   | in     | Number of points                             |
+    | ~nucl_num~            | ~int64_t~                   | in     | Number of nuclei                             |
+    | ~coord~               | ~double[3][point_num]~      | in     | Coordinates                                  |
+    | ~nucl_coord~          | ~double[3][nucl_num]~       | in     | Nuclear  coordinates                         |
+    | ~nucleus_index~       | ~int64_t[nucl_num]~         | in     | Index of the 1st shell of each nucleus       |
+    | ~nucleus_shell_num~   | ~int64_t[nucl_num]~         | in     | Number of shells per nucleus                 |
+    | ~nucleus_range~       | ~double[nucl_num]~          | in     | Range beyond which all is zero               |
+    | ~nucleus_max_ang_mom~ | ~int32_t[nucl_num]~         | in     | Maximum angular momentum per nucleus         |
+    | ~shell_ang_mom~       | ~int32_t[shell_num]~        | in     | Angular momentum of each shell               |
+    | ~shell_prim_index~    | ~int64_t[shell_num]~        | in     | Index of the 1st primitive of each shell     |
+    | ~shell_prim_num~      | ~int64_t[shell_num]~        | in     | Number of primitives per shell               |
+    | ~ao_factor~           | ~double[ao_num]~            | in     | Normalization factor of the AOs              |
+    | ~ao_expo~             | ~double[prim_num]~          | in     | Value, gradients and Laplacian of the shells |
+    | ~coef_normalized~     | ~double[prim_num]~          | in     | Value, gradients and Laplacian of the shells |
+    | ~ao_value~            | ~double[point_num][ao_num]~ | out    | Values of the AOs                            |
+
+     #+begin_src c :comments org :tangle (eval c) :noweb yes  :exports none
+#ifdef HAVE_HPC
+qmckl_exit_code
+qmckl_compute_ao_value_hpc_gaussian (const qmckl_context context,
+                                     const int64_t ao_num,
+                                     const int64_t shell_num,
+                                     const int32_t* restrict prim_num_per_nucleus,
+                                     const int64_t point_num,
+                                     const int64_t nucl_num,
+                                     const double* restrict coord,
+                                     const double* restrict nucl_coord,
+                                     const int64_t* restrict nucleus_index,
+                                     const int64_t* restrict nucleus_shell_num,
+                                     const double* nucleus_range,
+                                     const int32_t* restrict nucleus_max_ang_mom,
+                                     const int32_t* restrict shell_ang_mom,
+                                     const double* restrict ao_factor,
+                                     const qmckl_matrix expo_per_nucleus,
+                                     const qmckl_tensor coef_per_nucleus,
+                                     double* restrict const ao_value )
+{
+  int32_t lstart[32];
+  for (int32_t l=0 ; l<32 ; ++l) {
+    lstart[l] = l*(l+1)*(l+2)/6;
+  }
+
+  int64_t ao_index[shell_num+1];
+  int64_t size_max = 0;
+  int64_t prim_max = 0;
+  int64_t shell_max = 0;
+  {
+    int64_t k=0;
+    for (int inucl=0 ; inucl < nucl_num ; ++inucl) {
+      prim_max = prim_num_per_nucleus[inucl] > prim_max ?
+        prim_num_per_nucleus[inucl] : prim_max;
+      shell_max = nucleus_shell_num[inucl] > shell_max ?
+        nucleus_shell_num[inucl] : shell_max;
+      const int64_t ishell_start = nucleus_index[inucl];
+      const int64_t ishell_end   = nucleus_index[inucl] + nucleus_shell_num[inucl];
+      for (int64_t ishell = ishell_start ; ishell < ishell_end ; ++ishell) {
+        const int l = shell_ang_mom[ishell];
+        ao_index[ishell] = k;
+        k += lstart[l+1] - lstart[l];
+        size_max = size_max < lstart[l+1] ? lstart[l+1] : size_max;
+      }
+    }
+    ao_index[shell_num] = ao_num+1;
+  }
+
+  /* Don't compute polynomials when the radial part is zero. */
+  double cutoff = -log(1.e-12);
+
+#ifdef HAVE_OPENMP
+#pragma omp parallel
+#endif
+  {
+    qmckl_exit_code rc;
+    double ar2[prim_max];
+    int32_t powers[3*size_max];
+    double  poly_vgl[5*size_max];
+
+    double exp_mat[prim_max];
+    double ce_mat[shell_max];
+
+    double coef_mat[nucl_num][shell_max][prim_max];
+    for (int i=0 ; i<nucl_num ; ++i) {
+      for (int j=0 ; j<shell_max; ++j) {
+        for (int k=0 ; k<prim_max; ++k) {
+          coef_mat[i][j][k] = qmckl_ten3(coef_per_nucleus,k, j, i);
+        }
+      }
+    }
+
+#ifdef HAVE_OPENMP
+#pragma omp for
+#endif
+    for (int64_t ipoint=0 ; ipoint < point_num ; ++ipoint) {
+      const double e_coord[3] = { coord[ipoint],
+                                  coord[ipoint + point_num],
+                                  coord[ipoint + 2*point_num] };
+
+      for (int64_t inucl=0 ; inucl < nucl_num ; ++inucl) {
+        const double n_coord[3] = { nucl_coord[inucl],
+                                    nucl_coord[inucl + nucl_num],
+                                    nucl_coord[inucl + 2*nucl_num] };
+
+        /* Test if the point is in the range of the nucleus */
+        const double x = e_coord[0] - n_coord[0];
+        const double y = e_coord[1] - n_coord[1];
+        const double z = e_coord[2] - n_coord[2];
+
+        const double r2 = x*x + y*y + z*z;
+
+        if (r2 > cutoff * nucleus_range[inucl]) {
+          continue;
+        }
+
+        int64_t n_poly;
+        switch (nucleus_max_ang_mom[inucl]) {
+        case 0:
+          break;
+
+        case 1:
+          poly_vgl[0] = 0.;
+          poly_vgl[1] = x;
+          poly_vgl[2] = y;
+          poly_vgl[3] = z;
+          break;
+
+        case 2:
+          poly_vgl[0] = 0.;
+          poly_vgl[1] = x;
+          poly_vgl[2] = y;
+          poly_vgl[3] = z;
+          poly_vgl[4] = x*x;
+          poly_vgl[5] = x*y;
+          poly_vgl[6] = x*z;
+          poly_vgl[7] = y*y;
+          poly_vgl[8] = y*z;
+          poly_vgl[9] = z*z;
+          break;
+
+        default:
+          rc = qmckl_ao_polynomial_transp_vgl_hpc(context, e_coord, n_coord,
+                                                  nucleus_max_ang_mom[inucl],
+                                                  &n_poly, powers, (int64_t) 3,
+                                                  poly_vgl, size_max);
+          assert (rc == QMCKL_SUCCESS);
+          break;
+        }
+
+        /* Compute all exponents */
+
+        int64_t nidx = 0;
+        for (int64_t iprim = 0 ; iprim < prim_num_per_nucleus[inucl] ; ++iprim) {
+          const double v = qmckl_mat(expo_per_nucleus, iprim, inucl) * r2;
+          if (v <= cutoff) {
+            ar2[iprim] = v;
+            ++nidx;
+          } else {
+            break;
+          }
+        }
+
+        for (int64_t iprim = 0 ; iprim < nidx ; ++iprim) {
+          exp_mat[iprim] = exp(-ar2[iprim]);
+        }
+
+        for (int i=0 ; i<nucleus_shell_num[inucl] ; ++i) {
+            ce_mat[i] = 0.;
+        }
+        for (int k=0 ; k<nidx; ++k) {
+          for (int i=0 ; i<nucleus_shell_num[inucl] ; ++i) {
+            ce_mat[i] += coef_mat[inucl][i][k] * exp_mat[k];
+          }
+        }
+
+        const int64_t ishell_start = nucleus_index[inucl];
+        const int64_t ishell_end   = nucleus_index[inucl] + nucleus_shell_num[inucl];
+
+        for (int64_t ishell = ishell_start ; ishell < ishell_end ; ++ishell) {
+
+          const double s1 = ce_mat[ishell-ishell_start];
+          if (s1 == 0.0) continue;
+
+          const int64_t k = ao_index[ishell];
+          double* restrict const ao_value_1 = ao_value + ipoint*ao_num + k;
+
+          const int32_t l = shell_ang_mom[ishell];
+          const int32_t n = lstart[l+1]-lstart[l];
+
+          double* restrict poly_vgl_1 = NULL;
+          if (nidx > 0) {
+            const double* restrict f = ao_factor + k;
+            const int64_t idx = lstart[l];
+
+            poly_vgl_1 = &(poly_vgl[idx]);
+
+            switch (n) {
+            case(1):
+              ao_value_1[0] = s1 * f[0];
+              break;
+            case (3):
+#ifdef HAVE_OPENMP
+#pragma omp simd
+#endif
+              for (int il=0 ; il<3 ; ++il) {
+                ao_value_1[il] =  poly_vgl_1[il] * s1 * f[il];
+              }
+              break;
+            case(6):
+#ifdef HAVE_OPENMP
+#pragma omp simd
+#endif
+              for (int il=0 ; il<6 ; ++il) {
+                ao_value_1[il] =  poly_vgl_1[il] * s1 * f[il];
+              }
+              break;
+            default:
+#ifdef HAVE_OPENMP
+#pragma omp simd simdlen(8)
+#endif
+              for (int il=0 ; il<n ; ++il) {
+                ao_value_1[il] =  poly_vgl_1[il] * s1 * f[il];
+              }
+              break;
+            }
+          } else {
+            for (int64_t il=0 ; il<n ; ++il) {
+              ao_value_1[il] = 0.0;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return QMCKL_SUCCESS;
+}
+#endif
+     #+end_src
+
+*** Interfaces
+ #  #+CALL: generate_c_header(table=qmckl_ao_value_args_doc,rettyp=get_value("CRetType"),fname="qmckl_compute_ao_value"))
+ #  (Commented because the header needs to go into h_private_func)
+
+     #+begin_src c :tangle (eval h_private_func) :comments org
+    qmckl_exit_code qmckl_compute_ao_value_doc (
+          const qmckl_context context,
+          const int64_t ao_num,
+          const int64_t shell_num,
+          const int64_t point_num,
+          const int64_t nucl_num,
+          const double* coord,
+          const double* nucl_coord,
+          const int64_t* nucleus_index,
+          const int64_t* nucleus_shell_num,
+          const double* nucleus_range,
+          const int32_t* nucleus_max_ang_mom,
+          const int32_t* shell_ang_mom,
+          const double* ao_factor,
+          const double* shell_vgl,
+          double* const ao_value );
+     #+end_src
+
+     #+begin_src c :tangle (eval h_private_func) :comments org
+#ifdef HAVE_HPC
+    qmckl_exit_code qmckl_compute_ao_value_hpc_gaussian (
+          const qmckl_context context,
+          const int64_t ao_num,
+          const int64_t shell_num,
+          const int32_t* prim_num_per_nucleus,
+          const int64_t point_num,
+          const int64_t nucl_num,
+          const double* coord,
+          const double* nucl_coord,
+          const int64_t* nucleus_index,
+          const int64_t* nucleus_shell_num,
+          const double* nucleus_range,
+          const int32_t* nucleus_max_ang_mom,
+          const int32_t* shell_ang_mom,
+          const double* ao_factor,
+          const qmckl_matrix expo_per_nucleus,
+          const qmckl_tensor coef_per_nucleus,
+          double* const ao_value );
+#endif
+     #+end_src
+
+     #+CALL: generate_c_interface(table=qmckl_ao_value_args_doc,rettyp=get_value("CRetType"),fname="qmckl_compute_ao_value_doc"))
+
+     #+RESULTS:
+     #+begin_src f90 :tangle (eval f) :comments org :exports none
+    integer(c_int32_t) function qmckl_compute_ao_value_doc &
+        (context, &
+         ao_num, &
+         shell_num, &
+         point_num, &
+         nucl_num, &
+         coord, &
+         nucl_coord, &
+         nucleus_index, &
+         nucleus_shell_num, &
+         nucleus_range, &
+         nucleus_max_ang_mom, &
+         shell_ang_mom, &
+         ao_factor, &
+         shell_vgl, &
+         ao_value) &
+        bind(C) result(info)
+
+      use, intrinsic :: iso_c_binding
+      implicit none
+
+      integer (c_int64_t) , intent(in)  , value :: context
+      integer (c_int64_t) , intent(in)  , value :: ao_num
+      integer (c_int64_t) , intent(in)  , value :: shell_num
+      integer (c_int64_t) , intent(in)  , value :: point_num
+      integer (c_int64_t) , intent(in)  , value :: nucl_num
+      real    (c_double ) , intent(in)          :: coord(point_num,3)
+      real    (c_double ) , intent(in)          :: nucl_coord(nucl_num,3)
+      integer (c_int64_t) , intent(in)          :: nucleus_index(nucl_num)
+      integer (c_int64_t) , intent(in)          :: nucleus_shell_num(nucl_num)
+      real    (c_double ) , intent(in)          :: nucleus_range(nucl_num)
+      integer (c_int32_t) , intent(in)          :: nucleus_max_ang_mom(nucl_num)
+      integer (c_int32_t) , intent(in)          :: shell_ang_mom(shell_num)
+      real    (c_double ) , intent(in)          :: ao_factor(ao_num)
+      real    (c_double ) , intent(in)          :: shell_vgl(shell_num,5,point_num)
+      real    (c_double ) , intent(out)         :: ao_value(ao_num,point_num)
+
+      integer(c_int32_t), external :: qmckl_compute_ao_value_doc_f
+      info = qmckl_compute_ao_value_doc_f &
+             (context, &
+         ao_num, &
+         shell_num, &
+         point_num, &
+         nucl_num, &
+         coord, &
+         nucl_coord, &
+         nucleus_index, &
+         nucleus_shell_num, &
+         nucleus_range, &
+         nucleus_max_ang_mom, &
+         shell_ang_mom, &
+         ao_factor, &
+         shell_vgl, &
+         ao_value)
+
+    end function qmckl_compute_ao_value_doc
+     #+end_src
+
+**** Provide                                                       :noexport:
+
+     #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
+qmckl_exit_code qmckl_provide_ao_value(qmckl_context context);
+     #+end_src
+
+     #+begin_src c :comments org :tangle (eval c) :noweb yes  :exports none
+qmckl_exit_code qmckl_provide_ao_value(qmckl_context context)
+{
+
+  if (qmckl_context_check(context) == QMCKL_NULL_CONTEXT) {
+    return qmckl_failwith( context,
+                           QMCKL_INVALID_CONTEXT,
+                           "qmckl_provide_ao_value",
+                           NULL);
+  }
+
+  qmckl_context_struct* const ctx = (qmckl_context_struct*) context;
+  assert (ctx != NULL);
+
+  if (!ctx->ao_basis.provided) {
+    return qmckl_failwith( context,
+                           QMCKL_NOT_PROVIDED,
+                           "qmckl_ao_value",
+                           NULL);
+  }
+
+  /* Compute if necessary */
+  if (ctx->point.date > ctx->ao_basis.ao_value_date) {
+
+    qmckl_exit_code rc;
+
+    /* Provide required data */
+#ifndef HAVE_HPC
+    rc = qmckl_provide_ao_basis_shell_vgl(context);
+    if (rc != QMCKL_SUCCESS) {
+        return qmckl_failwith( context, rc, "qmckl_provide_ao_basis_shell_vgl", NULL);
+    }
+#endif
+
+    /* Allocate array */
+    if (ctx->ao_basis.ao_value == NULL) {
+
+      qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
+      mem_info.size = ctx->ao_basis.ao_num * 5 * ctx->point.num * sizeof(double);
+      double* ao_value = (double*) qmckl_malloc(context, mem_info);
+
+      if (ao_value == NULL) {
+        return qmckl_failwith( context,
+                               QMCKL_ALLOCATION_FAILED,
+                               "qmckl_ao_basis_ao_value",
+                               NULL);
+      }
+      ctx->ao_basis.ao_value = ao_value;
+    }
+
+    if (ctx->ao_basis.ao_vgl_date == ctx->point.date) {
+
+      // ao_vgl has been computed at this step: Just copy the data.
+
+      double * v = &(ctx->ao_basis.ao_value[0]);
+      double * vgl = &(ctx->ao_basis.ao_vgl[0]);
+      for (int i=0 ; i<ctx->point.num ; ++i) {
+        for (int k=0 ; k<ctx->ao_basis.ao_num ; ++k) {
+          v[k] = vgl[k];
+        }
+        v   += ctx->ao_basis.ao_num;
+        vgl += ctx->ao_basis.ao_num * 5;
+      }
+
+    } else {
+
+#ifdef HAVE_HPC
+      if (ctx->ao_basis.type == 'G') {
+        rc = qmckl_compute_ao_value_hpc_gaussian(context,
+                                                 ctx->ao_basis.ao_num,
+                                                 ctx->ao_basis.shell_num,
+                                                 ctx->ao_basis.prim_num_per_nucleus,
+                                                 ctx->point.num,
+                                                 ctx->nucleus.num,
+                                                 ctx->point.coord.data,
+                                                 ctx->nucleus.coord.data,
+                                                 ctx->ao_basis.nucleus_index,
+                                                 ctx->ao_basis.nucleus_shell_num,
+                                                 ctx->ao_basis.nucleus_range,
+                                                 ctx->ao_basis.nucleus_max_ang_mom,
+                                                 ctx->ao_basis.shell_ang_mom,
+                                                 ctx->ao_basis.ao_factor,
+                                                 ctx->ao_basis.expo_per_nucleus,
+                                                 ctx->ao_basis.coef_per_nucleus,
+                                                 ctx->ao_basis.ao_value);
+        /*
+          } else if (ctx->ao_basis.type == 'S') {
+          rc = qmck_compute_ao_value_hpc_slater(context,
+          ctx->ao_basis.ao_num,
+          ctx->ao_basis.shell_num,
+          ctx->ao_basis.prim_num,
+          ctx->point.num,
+          ctx->nucleus.num,
+          ctx->point.coord.data,
+          ctx->nucleus.coord.data,
+          ctx->ao_basis.nucleus_index,
+          ctx->ao_basis.nucleus_shell_num,
+          ctx->ao_basis.nucleus_range,
+          ctx->ao_basis.nucleus_max_ang_mom,
+          ctx->ao_basis.shell_ang_mom,
+          ctx->ao_basis.shell_prim_index,
+          ctx->ao_basis.shell_prim_num,
+          ctx->ao_basis.ao_factor,
+          ctx->ao_basis.exponent,
+          ctx->ao_basis.coefficient_normalized,
+          ctx->ao_basis.ao_value);
+        ,*/
+      } else {
+        rc = qmckl_compute_ao_value_doc(context,
+                                        ctx->ao_basis.ao_num,
+                                        ctx->ao_basis.shell_num,
+                                        ctx->point.num,
+                                        ctx->nucleus.num,
+                                        ctx->point.coord.data,
+                                        ctx->nucleus.coord.data,
+                                        ctx->ao_basis.nucleus_index,
+                                        ctx->ao_basis.nucleus_shell_num,
+                                        ctx->ao_basis.nucleus_range,
+                                        ctx->ao_basis.nucleus_max_ang_mom,
+                                        ctx->ao_basis.shell_ang_mom,
+                                        ctx->ao_basis.ao_factor,
+                                        ctx->ao_basis.shell_vgl,
+                                        ctx->ao_basis.ao_value);
+      }
+#else
+      rc = qmckl_compute_ao_value_doc(context,
+                                      ctx->ao_basis.ao_num,
+                                      ctx->ao_basis.shell_num,
+                                      ctx->point.num,
+                                      ctx->nucleus.num,
+                                      ctx->point.coord.data,
+                                      ctx->nucleus.coord.data,
+                                      ctx->ao_basis.nucleus_index,
+                                      ctx->ao_basis.nucleus_shell_num,
+                                      ctx->ao_basis.nucleus_range,
+                                      ctx->ao_basis.nucleus_max_ang_mom,
+                                      ctx->ao_basis.shell_ang_mom,
+                                      ctx->ao_basis.ao_factor,
+                                      ctx->ao_basis.shell_vgl,
+                                      ctx->ao_basis.ao_value);
+#endif
+      if (rc != QMCKL_SUCCESS) {
+        return rc;
+      }
+
+    }
+
+    ctx->ao_basis.ao_value_date = ctx->date;
+  }
+
+  return QMCKL_SUCCESS;
+}
+     #+end_src
+
+**** Test                                                          :noexport:
+
+     #+begin_src python :results output :exports none
+import numpy as np
+from math import sqrt
+
+h0 = 1.e-4
+def f(a,x,y):
+    return np.sum( [c * np.exp( -b*(np.linalg.norm(x-y))**2) for b,c in a] )
+
+elec_26_w1 = np.array( [  1.49050402641, 2.90106987953, -1.05920815468  ] )
+elec_15_w2 = np.array( [  -2.20180344582,-1.9113150239,  2.2193744778600002 ] )
+nucl_1    = np.array( [ -2.302574592081335e+00, -3.542027060505035e-01, -5.334129934317614e-02] )
+
+#double ao_value[prim_num][5][elec_num];
+x = elec_26_w1 ; y = nucl_1
+a = [( 4.0382999999999998e+02, 1.4732000000000000e-03 * 5.9876577632594533e+04),
+     ( 1.2117000000000000e+02, 1.2672500000000000e-02 * 7.2836806319891484e+03),
+     ( 4.6344999999999999e+01, 5.8045100000000002e-02 * 1.3549226646722386e+03),
+     ( 1.9721000000000000e+01, 1.7051030000000000e-01 * 3.0376315094739988e+02),
+     ( 8.8623999999999992e+00, 3.1859579999999998e-01 * 7.4924579607137730e+01),
+     ( 3.9962000000000000e+00, 3.8450230000000002e-01 * 1.8590543353806009e+01),
+     ( 1.7636000000000001e+00, 2.7377370000000001e-01 * 4.4423176930919421e+00),
+     ( 7.0618999999999998e-01, 7.4396699999999996e-02 * 8.9541051939952665e-01)]
+
+norm = sqrt(3.)
+# x^2 * g(r)
+print ( "[26][0][219] : %25.15e"%(fx(a,x,y)) )
+print ( "[26][1][219] : %25.15e"%(df(a,x,y,1)) )
+print ( "[26][2][219] : %25.15e"%(df(a,x,y,2)) )
+print ( "[26][3][219] : %25.15e"%(df(a,x,y,3)) )
+print ( "[26][4][219] : %25.15e"%(lf(a,x,y)) )
+
+print ( "[26][0][220] : %25.15e"%(norm*f(a,x,y) * (x[0] - y[0]) * (x[1] - y[1]) ))
+print ( "[26][1][220] : %25.15e"%(norm*df(a,x,y,1)* (x[0] - y[0]) * (x[1] - y[1]) + norm*f(a,x,y) * (x[1] - y[1])) )
+
+print ( "[26][0][221] : %25.15e"%(norm*f(a,x,y) * (x[0] - y[0]) * (x[2] - y[2])) )
+print ( "[26][1][221] : %25.15e"%(norm*df(a,x,y,1)* (x[0] - y[0]) * (x[2] - y[2]) + norm*f(a,x,y) * (x[2] - y[2])) )
+
+print ( "[26][0][222] : %25.15e"%(f(a,x,y) * (x[1] - y[1]) * (x[1] - y[1])) )
+print ( "[26][1][222] : %25.15e"%(df(a,x,y,1)* (x[1] - y[1]) * (x[1] - y[1])) )
+
+print ( "[26][0][223] : %25.15e"%(norm*f(a,x,y) * (x[1] - y[1]) * (x[2] - y[2])) )
+print ( "[26][1][223] : %25.15e"%(norm*df(a,x,y,1)* (x[1] - y[1]) * (x[2] - y[2])) )
+
+print ( "[26][0][224] : %25.15e"%(f(a,x,y) * (x[2] - y[2]) * (x[2] - y[2])) )
+print ( "[26][1][224] : %25.15e"%(df(a,x,y,1)* (x[2] - y[2]) * (x[2] - y[2])) )
+
+     #+end_src
+
+     #+RESULTS:
+
+      #+begin_src c :tangle (eval c_test) :exports none
+{
+#define walk_num 1 // chbrclf_walk_num
+#define elec_num chbrclf_elec_num
+#define shell_num chbrclf_shell_num
+#define ao_num chbrclf_ao_num
+
+int64_t elec_up_num   = chbrclf_elec_up_num;
+int64_t elec_dn_num   = chbrclf_elec_dn_num;
+double* elec_coord    = &(chbrclf_elec_coord[0][0][0]);
+
+rc = qmckl_set_electron_num (context, elec_up_num, elec_dn_num);
+assert (rc == QMCKL_SUCCESS);
+
+rc = qmckl_set_electron_walk_num (context, walk_num);
+assert (rc == QMCKL_SUCCESS);
+
+assert(qmckl_electron_provided(context));
+
+rc = qmckl_set_electron_coord (context, 'N', elec_coord, walk_num*elec_num*3);
+assert(rc == QMCKL_SUCCESS);
+
+
+double ao_value[elec_num][ao_num];
+
+rc = qmckl_get_ao_basis_ao_value(context, &(ao_value[0][0]),
+         (int64_t) elec_num*ao_num);
+assert (rc == QMCKL_SUCCESS);
+
+printf("\n");
+printf(" ao_value ao_value[26][219] %25.15e\n", ao_value[26][219]);
+printf(" ao_value ao_value[26][220] %25.15e\n", ao_value[26][220]);
+printf(" ao_value ao_value[26][221] %25.15e\n", ao_value[26][221]);
+printf(" ao_value ao_value[26][222] %25.15e\n", ao_value[26][222]);
+printf(" ao_value ao_value[26][223] %25.15e\n", ao_value[26][223]);
+printf(" ao_value ao_value[26][224] %25.15e\n", ao_value[26][224]);
+printf("\n");
+
+assert( fabs(ao_value[26][219] - (  1.020298798341620e-08)) < 1.e-14 );
+assert( fabs(ao_value[26][220] - (  1.516643537739178e-08)) < 1.e-14 );
+assert( fabs(ao_value[26][221] - ( -4.686370882518819e-09)) < 1.e-14 );
+assert( fabs(ao_value[26][222] - (  7.514816980753531e-09)) < 1.e-14 );
+assert( fabs(ao_value[26][223] - ( -4.021908374204471e-09)) < 1.e-14 );
+assert( fabs(ao_value[26][224] - (  7.175045873560788e-10)) < 1.e-14 );
+
+}
+
+      #+end_src
+
+** Value, gradients, Laplacian
    :PROPERTIES:
    :Name:     qmckl_compute_ao_vgl
    :CRetType: qmckl_exit_code
    :FRetType: qmckl_exit_code
    :END:
+*** Unoptimized version
+     #+NAME: qmckl_ao_vgl_args_doc
+    | Variable              | Type                              | In/Out | Description                                  |
+    |-----------------------+-----------------------------------+--------+----------------------------------------------|
+    | ~context~             | ~qmckl_context~                   | in     | Global state                                 |
+    | ~ao_num~              | ~int64_t~                         | in     | Number of AOs                                |
+    | ~shell_num~           | ~int64_t~                         | in     | Number of shells                             |
+    | ~point_num~           | ~int64_t~                         | in     | Number of points                             |
+    | ~nucl_num~            | ~int64_t~                         | in     | Number of nuclei                             |
+    | ~coord~               | ~double[3][point_num]~            | in     | Coordinates                                  |
+    | ~nucl_coord~          | ~double[3][nucl_num]~             | in     | Nuclear  coordinates                         |
+    | ~nucleus_index~       | ~int64_t[nucl_num]~               | in     | Index of the 1st shell of each nucleus       |
+    | ~nucleus_shell_num~   | ~int64_t[nucl_num]~               | in     | Number of shells per nucleus                 |
+    | ~nucleus_range~       | ~double[nucl_num]~                | in     | Range beyond which all is zero               |
+    | ~nucleus_max_ang_mom~ | ~int32_t[nucl_num]~               | in     | Maximum angular momentum per nucleus         |
+    | ~shell_ang_mom~       | ~int32_t[shell_num]~              | in     | Angular momentum of each shell               |
+    | ~ao_factor~           | ~double[ao_num]~                  | in     | Normalization factor of the AOs              |
+    | ~shell_vgl~           | ~double[point_num][5][shell_num]~ | in     | Value, gradients and Laplacian of the shells |
+    | ~ao_vgl~              | ~double[point_num][5][ao_num]~    | out    | Value, gradients and Laplacian of the AOs    |
 
-** Unoptimized version
-    #+NAME: qmckl_ao_vgl_args_doc
-   | Variable              | Type                              | In/Out | Description                                  |
-   |-----------------------+-----------------------------------+--------+----------------------------------------------|
-   | ~context~             | ~qmckl_context~                   | in     | Global state                                 |
-   | ~ao_num~              | ~int64_t~                         | in     | Number of AOs                                |
-   | ~shell_num~           | ~int64_t~                         | in     | Number of shells                             |
-   | ~point_num~           | ~int64_t~                         | in     | Number of points                             |
-   | ~nucl_num~            | ~int64_t~                         | in     | Number of nuclei                             |
-   | ~coord~               | ~double[3][point_num]~            | in     | Coordinates                                  |
-   | ~nucl_coord~          | ~double[3][nucl_num]~             | in     | Nuclear  coordinates                         |
-   | ~nucleus_index~       | ~int64_t[nucl_num]~               | in     | Index of the 1st shell of each nucleus       |
-   | ~nucleus_shell_num~   | ~int64_t[nucl_num]~               | in     | Number of shells per nucleus                 |
-   | ~nucleus_range~       | ~double[nucl_num]~                | in     | Range beyond which all is zero               |
-   | ~nucleus_max_ang_mom~ | ~int32_t[nucl_num]~               | in     | Maximum angular momentum per nucleus         |
-   | ~shell_ang_mom~       | ~int32_t[shell_num]~              | in     | Angular momentum of each shell               |
-   | ~ao_factor~           | ~double[ao_num]~                  | in     | Normalization factor of the AOs              |
-   | ~shell_vgl~           | ~double[point_num][5][shell_num]~ | in     | Value, gradients and Laplacian of the shells |
-   | ~ao_vgl~              | ~double[point_num][5][ao_num]~    | out    | Value, gradients and Laplacian of the AOs    |
-
-    #+begin_src f90 :comments org :tangle (eval f) :noweb yes
+     #+begin_src f90 :comments org :tangle (eval f) :noweb yes
 integer function qmckl_compute_ao_vgl_doc_f(context, &
      ao_num, shell_num, point_num, nucl_num, &
      coord, nucl_coord, nucleus_index, nucleus_shell_num, &
@@ -5443,34 +6321,34 @@ integer function qmckl_compute_ao_vgl_doc_f(context, &
 
   deallocate(poly_vgl, powers)
 end function qmckl_compute_ao_vgl_doc_f
-    #+end_src
+     #+end_src
 
-** HPC version
-    #+NAME: qmckl_ao_vgl_args_hpc_gaussian
-   | Variable              | Type                           | In/Out | Description                                  |
-   |-----------------------+--------------------------------+--------+----------------------------------------------|
-   | ~context~             | ~qmckl_context~                | in     | Global state                                 |
-   | ~ao_num~              | ~int64_t~                      | in     | Number of AOs                                |
-   | ~shell_num~           | ~int64_t~                      | in     | Number of shells                             |
-   | ~prim_num~            | ~int64_t~                      | in     | Number of primitives                         |
-   | ~point_num~           | ~int64_t~                      | in     | Number of points                             |
-   | ~nucl_num~            | ~int64_t~                      | in     | Number of nuclei                             |
-   | ~coord~               | ~double[3][point_num]~         | in     | Coordinates                                  |
-   | ~nucl_coord~          | ~double[3][nucl_num]~          | in     | Nuclear  coordinates                         |
-   | ~nucleus_index~       | ~int64_t[nucl_num]~            | in     | Index of the 1st shell of each nucleus       |
-   | ~nucleus_shell_num~   | ~int64_t[nucl_num]~            | in     | Number of shells per nucleus                 |
-   | ~nucleus_range~       | ~double[nucl_num]~             | in     | Range beyond which all is zero               |
-   | ~nucleus_max_ang_mom~ | ~int32_t[nucl_num]~            | in     | Maximum angular momentum per nucleus         |
-   | ~shell_ang_mom~       | ~int32_t[shell_num]~           | in     | Angular momentum of each shell               |
-   | ~shell_prim_index~    | ~int64_t[shell_num]~           | in     | Index of the 1st primitive of each shell     |
-   | ~shell_prim_num~      | ~int64_t[shell_num]~           | in     | Number of primitives per shell               |
-   | ~ao_factor~           | ~double[ao_num]~               | in     | Normalization factor of the AOs              |
-   | ~ao_expo~             | ~double[prim_num]~             | in     | Value, gradients and Laplacian of the shells |
-   | ~coef_normalized~     | ~double[prim_num]~             | in     | Value, gradients and Laplacian of the shells |
-   | ~ao_vgl~              | ~double[point_num][5][ao_num]~ | out    | Value, gradients and Laplacian of the AOs    |
+*** HPC version
+     #+NAME: qmckl_ao_vgl_args_hpc_gaussian
+    | Variable              | Type                           | In/Out | Description                                  |
+    |-----------------------+--------------------------------+--------+----------------------------------------------|
+    | ~context~             | ~qmckl_context~                | in     | Global state                                 |
+    | ~ao_num~              | ~int64_t~                      | in     | Number of AOs                                |
+    | ~shell_num~           | ~int64_t~                      | in     | Number of shells                             |
+    | ~prim_num~            | ~int64_t~                      | in     | Number of primitives                         |
+    | ~point_num~           | ~int64_t~                      | in     | Number of points                             |
+    | ~nucl_num~            | ~int64_t~                      | in     | Number of nuclei                             |
+    | ~coord~               | ~double[3][point_num]~         | in     | Coordinates                                  |
+    | ~nucl_coord~          | ~double[3][nucl_num]~          | in     | Nuclear  coordinates                         |
+    | ~nucleus_index~       | ~int64_t[nucl_num]~            | in     | Index of the 1st shell of each nucleus       |
+    | ~nucleus_shell_num~   | ~int64_t[nucl_num]~            | in     | Number of shells per nucleus                 |
+    | ~nucleus_range~       | ~double[nucl_num]~             | in     | Range beyond which all is zero               |
+    | ~nucleus_max_ang_mom~ | ~int32_t[nucl_num]~            | in     | Maximum angular momentum per nucleus         |
+    | ~shell_ang_mom~       | ~int32_t[shell_num]~           | in     | Angular momentum of each shell               |
+    | ~shell_prim_index~    | ~int64_t[shell_num]~           | in     | Index of the 1st primitive of each shell     |
+    | ~shell_prim_num~      | ~int64_t[shell_num]~           | in     | Number of primitives per shell               |
+    | ~ao_factor~           | ~double[ao_num]~               | in     | Normalization factor of the AOs              |
+    | ~ao_expo~             | ~double[prim_num]~             | in     | Value, gradients and Laplacian of the shells |
+    | ~coef_normalized~     | ~double[prim_num]~             | in     | Value, gradients and Laplacian of the shells |
+    | ~ao_vgl~              | ~double[point_num][5][ao_num]~ | out    | Value, gradients and Laplacian of the AOs    |
 
 
-    #+begin_src c :comments org :tangle (eval c) :noweb yes  :exports none
+     #+begin_src c :comments org :tangle (eval c) :noweb yes  :exports none
 #ifdef HAVE_HPC
 qmckl_exit_code
 qmckl_compute_ao_vgl_hpc_gaussian (
@@ -5529,7 +6407,7 @@ qmckl_compute_ao_vgl_hpc_gaussian (
   {
     qmckl_exit_code rc;
     double ar2[prim_max];
-    int32_t powers[prim_max];
+    int32_t powers[3*size_max];
     double  poly_vgl_l1[4][4] = {{1.0, 0.0, 0.0, 0.0},
                                  {0.0, 1.0, 0.0, 0.0},
                                  {0.0, 0.0, 1.0, 0.0},
@@ -5614,7 +6492,6 @@ qmckl_compute_ao_vgl_hpc_gaussian (
                                                   nucleus_max_ang_mom[inucl],
                                                   &n_poly, powers, (int64_t) 3,
                                                   &(poly_vgl[0][0]), size_max);
-
           assert (rc == QMCKL_SUCCESS);
           break;
         }
@@ -5785,14 +6662,13 @@ qmckl_compute_ao_vgl_hpc_gaussian (
   return QMCKL_SUCCESS;
 }
 #endif
-    #+end_src
+     #+end_src
 
-** Interfaces
-#  #+CALL: generate_c_header(table=qmckl_ao_vgl_args_doc,rettyp=get_value("CRetType"),fname="qmckl_compute_ao_vgl"))
-#  (Commented because the header needs to go into h_private_func)
+*** Interfaces
+ #  #+CALL: generate_c_header(table=qmckl_ao_vgl_args_doc,rettyp=get_value("CRetType"),fname="qmckl_compute_ao_vgl"))
+ #  (Commented because the header needs to go into h_private_func)
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_private_func) :comments org
+     #+begin_src c :tangle (eval h_private_func) :comments org
     qmckl_exit_code qmckl_compute_ao_vgl_doc (
           const qmckl_context context,
           const int64_t ao_num,
@@ -5809,8 +6685,9 @@ qmckl_compute_ao_vgl_hpc_gaussian (
           const double* ao_factor,
           const double* shell_vgl,
           double* const ao_vgl );
-    #+end_src
-    #+begin_src c :tangle (eval h_private_func) :comments org
+     #+end_src
+
+     #+begin_src c :tangle (eval h_private_func) :comments org
 #ifdef HAVE_HPC
     qmckl_exit_code qmckl_compute_ao_vgl_hpc_gaussian (
           const qmckl_context context,
@@ -5831,12 +6708,12 @@ qmckl_compute_ao_vgl_hpc_gaussian (
           const qmckl_tensor coef_per_nucleus,
           double* const ao_vgl );
 #endif
-    #+end_src
+     #+end_src
 
-    #+CALL: generate_c_interface(table=qmckl_ao_vgl_args_doc,rettyp=get_value("CRetType"),fname="qmckl_compute_ao_vgl_doc"))
+     #+CALL: generate_c_interface(table=qmckl_ao_vgl_args_doc,rettyp=get_value("CRetType"),fname="qmckl_compute_ao_vgl_doc"))
 
-    #+RESULTS:
-    #+begin_src f90 :tangle (eval f) :comments org :exports none
+     #+RESULTS:
+     #+begin_src f90 :tangle (eval f) :comments org :exports none
     integer(c_int32_t) function qmckl_compute_ao_vgl_doc &
         (context, &
          ao_num, &
@@ -5893,16 +6770,15 @@ qmckl_compute_ao_vgl_hpc_gaussian (
          ao_vgl)
 
     end function qmckl_compute_ao_vgl_doc
-    #+end_src
+     #+end_src
 
+**** Provide                                                       :noexport:
 
-*** Provide                                                        :noexport:
-
-    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
+     #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
 qmckl_exit_code qmckl_provide_ao_vgl(qmckl_context context);
-    #+end_src
+     #+end_src
 
-    #+begin_src c :comments org :tangle (eval c) :noweb yes  :exports none
+     #+begin_src c :comments org :tangle (eval c) :noweb yes  :exports none
 qmckl_exit_code qmckl_provide_ao_vgl(qmckl_context context)
 {
 
@@ -6035,11 +6911,11 @@ qmckl_exit_code qmckl_provide_ao_vgl(qmckl_context context)
 
   return QMCKL_SUCCESS;
 }
-    #+end_src
+     #+end_src
 
-*** Test                                                           :noexport:
+**** Test                                                          :noexport:
 
-    #+begin_src python :results output :exports none
+     #+begin_src python :results output :exports none
 import numpy as np
 from math import sqrt
 
@@ -6108,11 +6984,11 @@ print ( "[26][1][223] : %25.15e"%(norm*df(a,x,y,1)* (x[1] - y[1]) * (x[2] - y[2]
 print ( "[26][0][224] : %25.15e"%(f(a,x,y) * (x[2] - y[2]) * (x[2] - y[2])) )
 print ( "[26][1][224] : %25.15e"%(df(a,x,y,1)* (x[2] - y[2]) * (x[2] - y[2])) )
 
-    #+end_src
+     #+end_src
 
-    #+RESULTS:
+     #+RESULTS:
 
-     #+begin_src c :tangle (eval c_test) :exports none
+      #+begin_src c :tangle (eval c_test) :exports none
 {
 #define walk_num 1 // chbrclf_walk_num
 #define elec_num chbrclf_elec_num
@@ -6207,7 +7083,7 @@ assert( fabs(ao_vgl[26][4][224] - (  3.153244195820293e-08)) < 1.e-14 );
 
 }
 
-     #+end_src
+      #+end_src
 
 * End of files                                                     :noexport:
 

--- a/org/qmckl_jastrow.org
+++ b/org/qmckl_jastrow.org
@@ -11,7 +11,7 @@
   \[
   J(\mathbf{r},\mathbf{R}) = J_{\text{eN}}(\mathbf{r},\mathbf{R}) + J_{\text{ee}}(\mathbf{r}) + J_{\text{eeN}}(\mathbf{r},\mathbf{R})
   \]
-
+  
   In the following, we us the notations $r_{ij} = |\mathbf{r}_i - \mathbf{r}_j|$ and
   $R_{i\alpha} = |\mathbf{r}_i - \mathbf{R}_\alpha|$.
 
@@ -57,7 +57,6 @@
 
   The terms $J_{\text{ee}}^\infty$ and $J_{\text{eN}}^\infty$ are shifts to ensure that
   $J_{\text{ee}}$ and $J_{\text{eN}}$ have an asymptotic value of zero.
-
 
 * Headers                                                          :noexport:
   #+begin_src elisp :noexport :results none
@@ -108,6 +107,7 @@ int main() {
 #include <assert.h>
 #include <math.h>
 
+
 #include <stdio.h>
 
 #include "qmckl.h"
@@ -116,6 +116,12 @@ int main() {
 #include "qmckl_memory_private_func.h"
 #include "qmckl_jastrow_private_func.h"
 #include "qmckl_jastrow_private_type.h"
+
+#ifdef HAVE_CUBLAS_OFFLOAD
+#include "cublas_v2.h"
+#endif
+
+
   #+end_src
 
 * Context
@@ -151,7 +157,6 @@ int main() {
     | ~factor_en_deriv_e_date~  | ~uint64_t~                            | out    | Keep track of the date for the en derivative                      |
     | ~factor_een_deriv_e~      | ~double[4][nelec][walk_num]~          | out    | Derivative of the Jastrow factor: electron-electron-nucleus  part |
     | ~factor_een_deriv_e_date~ | ~uint64_t~                            | out    | Keep track of the date for the een derivative                     |
-    | ~offload_type~            | ~qmckl_jastrow_offload_type~          | in     | Enum type to change offload type at runtime                       |
 
   computed data:
 
@@ -328,14 +333,6 @@ kappa_inv = 1.0/kappa
 
 ** Data structure
 
-#+begin_src c :comments org :tangle (eval h_type)
-typedef enum qmckl_jastrow_offload_type{
-  OFFLOAD_NONE,
-  OFFLOAD_OPENACC,
-  OFFLOAD_CUBLAS
-} qmckl_jastrow_offload_type;
-#+end_src
-
    #+begin_src c :comments org :tangle (eval h_private_type)
 typedef struct qmckl_jastrow_struct{
   int32_t  uninitialized;
@@ -381,7 +378,10 @@ typedef struct qmckl_jastrow_struct{
   uint64_t  een_rescaled_n_deriv_e_date;
   bool     provided;
   char *   type;
-  qmckl_jastrow_offload_type offload_type;
+
+  #ifdef HAVE_HPC
+  bool     gpu_offload;
+  #endif
 } qmckl_jastrow_struct;
     #+end_src
 
@@ -426,7 +426,6 @@ qmckl_exit_code  qmckl_get_jastrow_type_nucl_vector  (qmckl_context context, int
 qmckl_exit_code  qmckl_get_jastrow_aord_vector       (qmckl_context context, double * const aord_vector, const int64_t size_max);
 qmckl_exit_code  qmckl_get_jastrow_bord_vector       (qmckl_context context, double * const bord_vector, const int64_t size_max);
 qmckl_exit_code  qmckl_get_jastrow_cord_vector       (qmckl_context context, double * const cord_vector, const int64_t size_max);
-qmckl_exit_code  qmckl_get_jastrow_offload_type      (qmckl_context context, qmckl_jastrow_offload_type * const offload_type);
    #+end_src
 
    Along with these core functions, calculation of the jastrow factor
@@ -724,32 +723,6 @@ qmckl_get_jastrow_cord_vector (const qmckl_context context,
   return QMCKL_SUCCESS;
 }
 
-qmckl_exit_code qmckl_get_jastrow_offload_type (const qmckl_context context, qmckl_jastrow_offload_type* const offload_type) {
-
-  if (qmckl_context_check(context) == QMCKL_NULL_CONTEXT) {
-    return (char) 0;
-  }
-
-  if (offload_type == NULL) {
-    return qmckl_failwith( context,
-                           QMCKL_INVALID_ARG_2,
-                           "qmckl_get_jastrow_offload_type",
-                           "offload_type is a null pointer");
-  }
-
-  qmckl_context_struct* const ctx = (qmckl_context_struct* const) context;
-  assert (ctx != NULL);
-
-  int32_t mask = 1 << 0;
-
-  if ( (ctx->jastrow.uninitialized & mask) != 0) {
-    return QMCKL_NOT_PROVIDED;
-  }
-
-  *offload_type = ctx->jastrow.offload_type;
-  return QMCKL_SUCCESS;
-}
-
    #+end_src
 
 ** Initialization functions
@@ -764,7 +737,6 @@ qmckl_exit_code  qmckl_set_jastrow_type_nucl_vector  (qmckl_context context, con
 qmckl_exit_code  qmckl_set_jastrow_aord_vector       (qmckl_context context, const double * aord_vector, const int64_t size_max);
 qmckl_exit_code  qmckl_set_jastrow_bord_vector       (qmckl_context context, const double * bord_vector, const int64_t size_max);
 qmckl_exit_code  qmckl_set_jastrow_cord_vector       (qmckl_context context, const double * cord_vector, const int64_t size_max);
-qmckl_exit_code  qmckl_set_jastrow_offload_type      (qmckl_context context, const qmckl_jastrow_offload_type offload_type);
    #+end_src
 
    #+NAME:pre2
@@ -1101,14 +1073,6 @@ qmckl_set_jastrow_cord_vector(qmckl_context context,
   <<post2>>
 }
 
-qmckl_exit_code
-qmckl_set_jastrow_offload_type(qmckl_context context, const qmckl_jastrow_offload_type offload_type)
-{
-<<pre2>>
-  ctx->jastrow.offload_type = offload_type;
-  return QMCKL_SUCCESS;
-}
-
    #+end_src
 
  When the required information is completely entered, other data structures are
@@ -1154,6 +1118,11 @@ qmckl_exit_code qmckl_finalize_jastrow(qmckl_context context) {
                            "qmckl_nucleus",
                            NULL);
   }
+
+  /* Decide if the Jastrow if offloaded on GPU or not */
+#if defined(HAVE_HPC) && (defined(HAVE_CUBLAS_OFFLOAD) || defined(HAVE_OPENACC_OFFLOAD) || defined(HAVE_OPENMP_OFFLOAD))
+  ctx->jastrow.gpu_offload = true; // ctx->electron.num > 100;
+#endif
 
   qmckl_exit_code rc = QMCKL_SUCCESS;
   return rc;
@@ -1540,16 +1509,15 @@ qmckl_exit_code qmckl_compute_asymp_jasb (
 }
 #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_asymp_jasb_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+#   #+CALL: generate_c_header(table=qmckl_asymp_jasb_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
     qmckl_exit_code qmckl_compute_asymp_jasb (
-	  const qmckl_context context,
-	  const int64_t bord_num,
-	  const double* bord_vector,
-	  const double rescale_factor_kappa_ee,
-	  double* const asymp_jasb );
+          const qmckl_context context,
+          const int64_t bord_num,
+          const double* bord_vector,
+          const double rescale_factor_kappa_ee,
+          double* const asymp_jasb );
     #+end_src
 
 
@@ -1827,34 +1795,34 @@ end function qmckl_compute_factor_ee_f
 
 #+begin_src c   :comments org :tangle (eval c) :noweb yes
 qmckl_exit_code qmckl_compute_factor_ee (
-	  const qmckl_context context,
-	  const int64_t walk_num,
-	  const int64_t elec_num,
-	  const int64_t up_num,
-	  const int64_t bord_num,
-	  const double* bord_vector,
-	  const double* ee_distance_rescaled,
-	  const double* asymp_jasb,
-	  double* const factor_ee ) {
+      const qmckl_context context,
+      const int64_t walk_num,
+      const int64_t elec_num,
+      const int64_t up_num,
+      const int64_t bord_num,
+      const double* bord_vector,
+      const double* ee_distance_rescaled,
+      const double* asymp_jasb,
+      double* const factor_ee ) {
 
   int ipar; // can we use a smaller integer?
   double x, x1, spin_fact, power_ser;
 
-  if (context == QMCKL_NULL_CONTEXT) { 
+  if (context == QMCKL_NULL_CONTEXT) {
      return QMCKL_INVALID_CONTEXT;
-  } 
+  }
 
   if (walk_num <= 0) {
      return QMCKL_INVALID_ARG_2;
   }
-  
+
   if (elec_num <= 0) {
      return QMCKL_INVALID_ARG_3;
-  } 
+  }
 
   if (bord_num <= 0) {
      return QMCKL_INVALID_ARG_4;
-  } 
+  }
 
   for (int nw = 0; nw < walk_num; ++nw) {
     factor_ee[nw] = 0.0; // put init array here.
@@ -1865,9 +1833,9 @@ qmckl_exit_code qmckl_compute_factor_ee (
         x1 = x;
         power_ser = 0.0;
         spin_fact = 1.0;
-        ipar = 0; // index of asymp_jasb 
+        ipar = 0; // index of asymp_jasb
 
-        for (int p = 1; p < bord_num; ++p) { 
+        for (int p = 1; p < bord_num; ++p) {
           x = x * x1;
           power_ser = power_ser + bord_vector[p + 1] * x;
         }
@@ -1876,7 +1844,7 @@ qmckl_exit_code qmckl_compute_factor_ee (
           spin_fact = 0.5;
           ipar = 1;
         }
-        
+
         factor_ee[nw] = factor_ee[nw] + spin_fact * bord_vector[0]  * \
                                 x1 /  \
                                 (1.0 + bord_vector[1] *               \
@@ -1891,20 +1859,19 @@ qmckl_exit_code qmckl_compute_factor_ee (
 }
 #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_ee_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+#   #+CALL: generate_c_header(table=qmckl_factor_ee_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
     qmckl_exit_code qmckl_compute_factor_ee (
-	  const qmckl_context context,
-	  const int64_t walk_num,
-	  const int64_t elec_num,
-	  const int64_t up_num,
-	  const int64_t bord_num,
-	  const double* bord_vector,
-	  const double* ee_distance_rescaled,
-	  const double* asymp_jasb,
-	  double* const factor_ee );
+          const qmckl_context context,
+          const int64_t walk_num,
+          const int64_t elec_num,
+          const int64_t up_num,
+          const int64_t bord_num,
+          const double* bord_vector,
+          const double* ee_distance_rescaled,
+          const double* asymp_jasb,
+          double* const factor_ee );
     #+end_src
 
 
@@ -2063,7 +2030,6 @@ qmckl_exit_code qmckl_provide_factor_ee_deriv_e(qmckl_context context)
                                          ctx->jastrow.bord_vector,
                                          ctx->electron.ee_distance_rescaled,
                                          ctx->electron.ee_distance_rescaled_deriv_e,
-                                         ctx->jastrow.asymp_jasb,
                                          ctx->jastrow.factor_ee_deriv_e);
     if (rc != QMCKL_SUCCESS) {
       return rc;
@@ -2094,14 +2060,13 @@ qmckl_exit_code qmckl_provide_factor_ee_deriv_e(qmckl_context context)
     | ~bord_vector~                  | ~double[bord_num+1]~                      | in     | List of coefficients        |
     | ~ee_distance_rescaled~         | ~double[walk_num][elec_num][elec_num]~    | in     | Electron-electron distances |
     | ~ee_distance_rescaled_deriv_e~ | ~double[walk_num][4][elec_num][elec_num]~ | in     | Electron-electron distances |
-    | ~asymp_jasb~                   | ~double[2]~                               | in     | Electron-electron distances |
     | ~factor_ee_deriv_e~            | ~double[walk_num][4][elec_num]~           | out    | Electron-electron distances |
 
     #+begin_src f90 :comments org :tangle (eval f) :noweb yes
-integer function qmckl_compute_factor_ee_deriv_e_f( &
+integer function qmckl_compute_factor_ee_deriv_e_doc_f( &
      context, walk_num, elec_num, up_num, bord_num, &
      bord_vector, ee_distance_rescaled, ee_distance_rescaled_deriv_e,  &
-     asymp_jasb, factor_ee_deriv_e) &
+     factor_ee_deriv_e) &
      result(info)
   use qmckl
   implicit none
@@ -2110,10 +2075,9 @@ integer function qmckl_compute_factor_ee_deriv_e_f( &
   double precision      , intent(in)  :: bord_vector(bord_num + 1)
   double precision      , intent(in)  :: ee_distance_rescaled(elec_num, elec_num,walk_num)
   double precision      , intent(in)  :: ee_distance_rescaled_deriv_e(4,elec_num, elec_num,walk_num)   !TODO
-  double precision      , intent(in)  :: asymp_jasb(2)
   double precision      , intent(out) :: factor_ee_deriv_e(elec_num,4,walk_num)
 
-  integer*8 :: i, j, p, ipar, nw, ii
+  integer*8 :: i, j, p, nw, ii
   double precision   :: x, spin_fact, y
   double precision   :: den, invden, invden2, invden3, xinv
   double precision   :: lap1, lap2, lap3, third
@@ -2157,7 +2121,6 @@ integer function qmckl_compute_factor_ee_deriv_e_f( &
         invden2     = invden * invden
         invden3     = invden2 * invden
         xinv        = 1.0d0 / (x + 1.0d-18)
-        ipar        = 1
 
         dx(1) = ee_distance_rescaled_deriv_e(1, i, j, nw)
         dx(2) = ee_distance_rescaled_deriv_e(2, i, j, nw)
@@ -2199,43 +2162,154 @@ integer function qmckl_compute_factor_ee_deriv_e_f( &
   end do
   end do
 
-end function qmckl_compute_factor_ee_deriv_e_f
+end function qmckl_compute_factor_ee_deriv_e_doc_f
     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_ee_deriv_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+    #+begin_src c :comments org :tangle (eval c) :noweb yes
+qmckl_exit_code qmckl_compute_factor_ee_deriv_e_hpc(
+      const qmckl_context context,
+      const int64_t walk_num,
+      const int64_t elec_num,
+      const int64_t up_num,
+      const int64_t bord_num,
+      const double* bord_vector,
+      const double* ee_distance_rescaled,
+      const double* ee_distance_rescaled_deriv_e,
+      double* const factor_ee_deriv_e ) {
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
+  int64_t ii;
+  double  pow_ser_g[3];
+  double  dx[4];
+  double  x, spin_fact, y;
+  double  den, invden, invden2, invden3, xinv;
+  double  lap1, lap2, lap3, third;
+
+  if (context == QMCKL_NULL_CONTEXT) {
+    return QMCKL_INVALID_CONTEXT;
+  } 
+
+  if (walk_num <= 0) {
+    return QMCKL_INVALID_ARG_2;
+  } 
+
+  if (elec_num <= 0) {
+    return QMCKL_INVALID_ARG_3;
+  }
+
+  if (bord_num <= 0) {
+    return QMCKL_INVALID_ARG_4;
+  }
+
+  
+  for (int nw = 0; nw < walk_num; ++nw) {
+    for (int ii = 0; ii < 4; ++ii) {
+      for (int j = 0; j < elec_num; ++j) {
+        factor_ee_deriv_e[j + ii * elec_num + nw * elec_num * 4]  = 0.0;
+      }
+    }
+  }
+  
+  third = 1.0 / 3.0;
+
+  for (int nw = 0; nw < walk_num; ++nw) {
+    for (int i = 0; i < elec_num; ++i) {
+      for (int j = 0; j < elec_num; ++j) {
+        x = ee_distance_rescaled[j + i * elec_num + nw * elec_num * elec_num];
+        if (fabs(x) < 1.0e-18) continue;
+        for (int ii = 0; ii < 3; ++ii){
+            pow_ser_g[ii] = 0.0;
+        }    
+        spin_fact   = 1.0;
+        den         = 1.0 + bord_vector[1] * x;
+        invden      = 1.0 / den;
+        invden2     = invden * invden;
+        invden3     = invden2 * invden;
+        xinv        = 1.0 / (x + 1.0e-18);
+        
+        dx[0] = ee_distance_rescaled_deriv_e[0 \
+                                           + j * 4 + i * 4 * elec_num \
+                                           + nw * 4 * elec_num * elec_num];
+        dx[1] = ee_distance_rescaled_deriv_e[1  \
+                                           + j * 4 + i * 4 * elec_num \
+                                           + nw * 4 * elec_num * elec_num];
+        dx[2] = ee_distance_rescaled_deriv_e[2  \
+                                           + j * 4 + i * 4 * elec_num \
+                                           + nw * 4 * elec_num * elec_num];
+        dx[3] = ee_distance_rescaled_deriv_e[3  \
+                                           + j * 4 + i * 4 * elec_num \
+                                           + nw * 4 * elec_num * elec_num];
+
+        if((i <= (up_num-1) && j <= (up_num-1) ) || (i > (up_num-1) && j > (up_num-1))) {
+          spin_fact = 0.5;
+        }
+
+        lap1 = 0.0;
+        lap2 = 0.0;
+        lap3 = 0.0;
+        for (int ii = 0; ii < 3; ++ii) {
+          x = ee_distance_rescaled[j + i * elec_num + nw * elec_num * elec_num];
+          if (fabs(x) < 1.0e-18) continue;
+          for (int p = 2; p < bord_num+1; ++p) {
+            y = p * bord_vector[(p-1) + 1] * x;
+            pow_ser_g[ii] = pow_ser_g[ii] + y * dx[ii];
+            lap1 = lap1 + (p - 1) * y * xinv * dx[ii] * dx[ii];
+            lap2 = lap2 + y;
+            x = x * ee_distance_rescaled[j + i * elec_num + nw * elec_num * elec_num];
+          }
+
+          lap3 = lap3 - 2.0 * bord_vector[1] * dx[ii] * dx[ii];
+
+          factor_ee_deriv_e[i  + ii * elec_num  + nw * elec_num * 4 ] +=              \
+                                       + spin_fact * bord_vector[0] * dx[ii] * invden2 \
+                                       + pow_ser_g[ii] ;
+        }
+
+        ii = 3;
+        lap2 = lap2 * dx[ii] * third;
+        lap3 = lap3 + den * dx[ii];
+        lap3 = lap3 * (spin_fact * bord_vector[0] * invden3);
+        factor_ee_deriv_e[i + ii*elec_num + nw * elec_num * 4] += lap1 + lap2 + lap3;
+
+      }
+    }
+  }
+  
+  return QMCKL_SUCCESS;
+}
+    #+end_src
+
+#   #+CALL: generate_c_header(table=qmckl_factor_ee_deriv_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+
+
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
     qmckl_exit_code qmckl_compute_factor_ee_deriv_e (
-	  const qmckl_context context,
-	  const int64_t walk_num,
-	  const int64_t elec_num,
-	  const int64_t up_num,
-	  const int64_t bord_num,
-	  const double* bord_vector,
-	  const double* ee_distance_rescaled,
-	  const double* ee_distance_rescaled_deriv_e,
-	  const double* asymp_jasb,
-	  double* const factor_ee_deriv_e );
+          const qmckl_context context,
+          const int64_t walk_num,
+          const int64_t elec_num,
+          const int64_t up_num,
+          const int64_t bord_num,
+          const double* bord_vector,
+          const double* ee_distance_rescaled,
+          const double* ee_distance_rescaled_deriv_e,
+          double* const factor_ee_deriv_e );
     #+end_src
 
 
-    #+CALL: generate_c_interface(table=qmckl_factor_ee_deriv_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+    #+CALL: generate_c_interface(table=qmckl_factor_ee_deriv_e_args,rettyp=get_value("CRetType"),fname="qmckl_compute_factor_ee_deriv_e_doc")
 
     #+RESULTS:
     #+begin_src f90 :tangle (eval f) :comments org :exports none
-integer(c_int32_t) function qmckl_compute_factor_ee_deriv_e &
-	(context, &
-		 walk_num, &
-		 elec_num, &
-		 up_num, &
-		 bord_num, &
-		 bord_vector, &
-		 ee_distance_rescaled, &
-		 ee_distance_rescaled_deriv_e, &
-		 asymp_jasb, &
-		 factor_ee_deriv_e) &
-	bind(C) result(info)
+integer(c_int32_t) function qmckl_compute_factor_ee_deriv_e_doc &
+    (context, &
+         walk_num, &
+         elec_num, &
+         up_num, &
+         bord_num, &
+         bord_vector, &
+         ee_distance_rescaled, &
+         ee_distance_rescaled_deriv_e, &
+         factor_ee_deriv_e) &
+        bind(C) result(info)
 
       use, intrinsic :: iso_c_binding
       implicit none
@@ -2245,27 +2319,77 @@ integer(c_int32_t) function qmckl_compute_factor_ee_deriv_e &
       integer (c_int64_t) , intent(in)  , value :: elec_num
       integer (c_int64_t) , intent(in)  , value :: up_num
       integer (c_int64_t) , intent(in)  , value :: bord_num
-      real    (c_double ) , intent(in)          :: bord_vector(bord_num + 1)
+      real    (c_double ) , intent(in)          :: bord_vector(bord_num+1)
       real    (c_double ) , intent(in)          :: ee_distance_rescaled(elec_num,elec_num,walk_num)
       real    (c_double ) , intent(in)          :: ee_distance_rescaled_deriv_e(elec_num,elec_num,4,walk_num)
-      real    (c_double ) , intent(in)          :: asymp_jasb(2)
       real    (c_double ) , intent(out)         :: factor_ee_deriv_e(elec_num,4,walk_num)
 
-      integer(c_int32_t), external :: qmckl_compute_factor_ee_deriv_e_f
-      info = qmckl_compute_factor_ee_deriv_e_f &
-	     (context, &
-		 walk_num, &
-		 elec_num, &
-		 up_num, &
-		 bord_num, &
-		 bord_vector, &
-		 ee_distance_rescaled, &
-		 ee_distance_rescaled_deriv_e, &
-		 asymp_jasb, &
-		 factor_ee_deriv_e)
+      integer(c_int32_t), external :: qmckl_compute_factor_ee_deriv_e_doc_f
+      info = qmckl_compute_factor_ee_deriv_e_doc_f &
+         (context, &
+         walk_num, &
+         elec_num, &
+         up_num, &
+         bord_num, &
+         bord_vector, &
+         ee_distance_rescaled, &
+         ee_distance_rescaled_deriv_e, &
+         factor_ee_deriv_e)
 
-    end function qmckl_compute_factor_ee_deriv_e
+    end function qmckl_compute_factor_ee_deriv_e_doc
     #+end_src
+    
+    #+begin_src c :tangle (eval h_private_func) :comments org
+    qmckl_exit_code qmckl_compute_factor_ee_deriv_e_hpc (
+      const qmckl_context context,
+      const int64_t walk_num,
+      const int64_t elec_num,
+      const int64_t up_num,
+      const int64_t bord_num,
+      const double* bord_vector,
+      const double* ee_distance_rescaled,
+      const double* ee_distance_rescaled_deriv_e,
+      double* const factor_ee_deriv_e );
+
+    #+end_src
+
+    #+begin_src c :tangle (eval h_private_func) :comments org
+    qmckl_exit_code qmckl_compute_factor_ee_deriv_e_doc (
+      const qmckl_context context,
+      const int64_t walk_num,
+      const int64_t elec_num,
+      const int64_t up_num,
+      const int64_t bord_num,
+      const double* bord_vector,
+      const double* ee_distance_rescaled,
+      const double* ee_distance_rescaled_deriv_e,
+      double* const factor_ee_deriv_e );
+    #+end_src
+
+
+    #+begin_src c :comments org :tangle (eval c) :noweb yes
+    qmckl_exit_code qmckl_compute_factor_ee_deriv_e (
+      const qmckl_context context,
+      const int64_t walk_num,
+      const int64_t elec_num,
+      const int64_t up_num,
+      const int64_t bord_num,
+      const double* bord_vector,
+      const double* ee_distance_rescaled,
+      const double* ee_distance_rescaled_deriv_e,
+      double* const factor_ee_deriv_e ) {
+
+      #ifdef HAVE_HPC
+      return qmckl_compute_factor_ee_deriv_e_hpc(context, walk_num, elec_num, up_num, bord_num, bord_vector, ee_distance_rescaled, ee_distance_rescaled_deriv_e, factor_ee_deriv_e ); 
+      #else
+      return qmckl_compute_factor_ee_deriv_e_doc(context, walk_num, elec_num, up_num, bord_num, bord_vector, ee_distance_rescaled, ee_distance_rescaled_deriv_e, factor_ee_deriv_e ); 
+      #endif
+}
+    #+end_src
+
+
+
+
 
 *** Test
     #+begin_src python :results output :exports none :noweb yes
@@ -2384,7 +2508,6 @@ assert(fabs(factor_ee_deriv_e[0][0][0]-0.16364894652107934) < 1.e-12);
 assert(fabs(factor_ee_deriv_e[0][1][0]+0.6927548119830084 ) < 1.e-12);
 assert(fabs(factor_ee_deriv_e[0][2][0]-0.073267755223968  ) < 1.e-12);
 assert(fabs(factor_ee_deriv_e[0][3][0]-1.5111672803213185 ) < 1.e-12);
-
      #+end_src
 
 ** Electron-nucleus component \(f_{en}\)
@@ -2589,20 +2712,20 @@ integer function qmckl_compute_factor_en_f( &
 
 end function qmckl_compute_factor_en_f
     #+end_src
-    
+
 
     #+begin_src c :comments org :tangle (eval c) :noweb yes
 qmckl_exit_code qmckl_compute_factor_en (
-	  const qmckl_context context,
-	  const int64_t walk_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t type_nucl_num,
-	  const int64_t* type_nucl_vector,
-	  const int64_t aord_num,
-	  const double* aord_vector,
-	  const double* en_distance_rescaled,
-	  double* const factor_en ) {
+      const qmckl_context context,
+      const int64_t walk_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t type_nucl_num,
+      const int64_t* type_nucl_vector,
+      const int64_t aord_num,
+      const double* aord_vector,
+      const double* en_distance_rescaled,
+      double* const factor_en ) {
 
   double  x, x1, power_ser;
 
@@ -2658,7 +2781,7 @@ qmckl_exit_code qmckl_compute_factor_en (
         x1 = x;
         power_ser = 0.0;
 
-        for (int p = 2; p < aord_num+1; ++p) { 
+        for (int p = 2; p < aord_num+1; ++p) {
           x = x * x1;
           power_ser = power_ser + aord_vector[(p+1)-1 + (type_nucl_vector[a]-1) * aord_num] * x;
         }
@@ -2676,21 +2799,20 @@ qmckl_exit_code qmckl_compute_factor_en (
     #+end_src
 
 
-    #+CALL: generate_c_header(table=qmckl_factor_en_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+#   #+CALL: generate_c_header(table=qmckl_factor_en_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
     qmckl_exit_code qmckl_compute_factor_en (
-	  const qmckl_context context,
-	  const int64_t walk_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t type_nucl_num,
-	  const int64_t* type_nucl_vector,
-	  const int64_t aord_num,
-	  const double* aord_vector,
-	  const double* en_distance_rescaled,
-	  double* const factor_en );
+          const qmckl_context context,
+          const int64_t walk_num,
+          const int64_t elec_num,
+          const int64_t nucl_num,
+          const int64_t type_nucl_num,
+          const int64_t* type_nucl_vector,
+          const int64_t aord_num,
+          const double* aord_vector,
+          const double* en_distance_rescaled,
+          double* const factor_en );
     #+end_src
 
 
@@ -2970,22 +3092,21 @@ integer function qmckl_compute_factor_en_deriv_e_f( &
 end function qmckl_compute_factor_en_deriv_e_f
     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_en_deriv_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+#   #+CALL: generate_c_header(table=qmckl_factor_en_deriv_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
     qmckl_exit_code qmckl_compute_factor_en_deriv_e (
-	  const qmckl_context context,
-	  const int64_t walk_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t type_nucl_num,
-	  const int64_t* type_nucl_vector,
-	  const int64_t aord_num,
-	  const double* aord_vector,
-	  const double* en_distance_rescaled,
-	  const double* en_distance_rescaled_deriv_e,
-	  double* const factor_en_deriv_e );
+          const qmckl_context context,
+          const int64_t walk_num,
+          const int64_t elec_num,
+          const int64_t nucl_num,
+          const int64_t type_nucl_num,
+          const int64_t* type_nucl_vector,
+          const int64_t aord_num,
+          const double* aord_vector,
+          const double* en_distance_rescaled,
+          const double* en_distance_rescaled_deriv_e,
+          double* const factor_en_deriv_e );
     #+end_src
 
 
@@ -2994,18 +3115,18 @@ end function qmckl_compute_factor_en_deriv_e_f
     #+RESULTS:
     #+begin_src f90 :tangle (eval f) :comments org :exports none
     integer(c_int32_t) function qmckl_compute_factor_en_deriv_e &
-	(context, &
-		 walk_num, &
-		 elec_num, &
-		 nucl_num, &
-		 type_nucl_num, &
-		 type_nucl_vector, &
-		 aord_num, &
-		 aord_vector, &
-		 en_distance_rescaled, &
-		 en_distance_rescaled_deriv_e, &
-		 factor_en_deriv_e) &
-	bind(C) result(info)
+        (context, &
+         walk_num, &
+         elec_num, &
+         nucl_num, &
+         type_nucl_num, &
+         type_nucl_vector, &
+         aord_num, &
+         aord_vector, &
+         en_distance_rescaled, &
+         en_distance_rescaled_deriv_e, &
+         factor_en_deriv_e) &
+        bind(C) result(info)
 
       use, intrinsic :: iso_c_binding
       implicit none
@@ -3017,24 +3138,24 @@ end function qmckl_compute_factor_en_deriv_e_f
       integer (c_int64_t) , intent(in)  , value :: type_nucl_num
       integer (c_int64_t) , intent(in)          :: type_nucl_vector(nucl_num)
       integer (c_int64_t) , intent(in)  , value :: aord_num
-      real    (c_double ) , intent(in)          :: aord_vector(aord_num + 1, type_nucl_num)
+      real    (c_double ) , intent(in)          :: aord_vector(type_nucl_num,aord_num+1)
       real    (c_double ) , intent(in)          :: en_distance_rescaled(elec_num,nucl_num,walk_num)
       real    (c_double ) , intent(in)          :: en_distance_rescaled_deriv_e(elec_num,nucl_num,4,walk_num)
       real    (c_double ) , intent(out)         :: factor_en_deriv_e(elec_num,4,walk_num)
 
       integer(c_int32_t), external :: qmckl_compute_factor_en_deriv_e_f
       info = qmckl_compute_factor_en_deriv_e_f &
-	     (context, &
-		 walk_num, &
-		 elec_num, &
-		 nucl_num, &
-		 type_nucl_num, &
-		 type_nucl_vector, &
-		 aord_num, &
-		 aord_vector, &
-		 en_distance_rescaled, &
-		 en_distance_rescaled_deriv_e, &
-		 factor_en_deriv_e)
+             (context, &
+         walk_num, &
+         elec_num, &
+         nucl_num, &
+         type_nucl_num, &
+         type_nucl_vector, &
+         aord_num, &
+         aord_vector, &
+         en_distance_rescaled, &
+         en_distance_rescaled_deriv_e, &
+         factor_en_deriv_e)
 
     end function qmckl_compute_factor_en_deriv_e
     #+end_src
@@ -3279,7 +3400,7 @@ qmckl_exit_code qmckl_provide_een_rescaled_e(qmckl_context context)
     | ~een_rescaled_e~          | ~double[walk_num][0:cord_num][elec_num][elec_num]~ | out    | Electron-electron rescaled distances |
 
     #+begin_src f90 :comments org :tangle (eval f) :noweb yes
-integer function qmckl_compute_een_rescaled_e_f( &
+integer function qmckl_compute_een_rescaled_e_doc_f( &
      context, walk_num, elec_num, cord_num, rescale_factor_kappa_ee,  &
      ee_distance, een_rescaled_e) &
      result(info)
@@ -3297,7 +3418,6 @@ integer function qmckl_compute_een_rescaled_e_f( &
   integer*8                           :: i, j, k, l, nw
 
   allocate(een_rescaled_e_ij(elec_num * (elec_num - 1) / 2, cord_num + 1))
-
 
   info = QMCKL_SUCCESS
 
@@ -3327,6 +3447,7 @@ integer function qmckl_compute_een_rescaled_e_f( &
   een_rescaled_e_ij       = 0.0d0
   een_rescaled_e_ij(:, 1) = 1.0d0
 
+
   k = 0
   do j = 1, elec_num
     do i = 1, j - 1
@@ -3334,6 +3455,7 @@ integer function qmckl_compute_een_rescaled_e_f( &
       een_rescaled_e_ij(k, 2) = dexp(-rescale_factor_kappa_ee * ee_distance(i, j, nw))
     end do
   end do
+
 
   do l = 2, cord_num
     do k = 1, elec_num * (elec_num - 1)/2
@@ -3343,6 +3465,7 @@ integer function qmckl_compute_een_rescaled_e_f( &
 
   ! prepare the actual een table
   een_rescaled_e(:, :, 0, nw) = 1.0d0
+
   do l = 1, cord_num
     k = 0
     do j = 1, elec_num
@@ -3363,31 +3486,30 @@ integer function qmckl_compute_een_rescaled_e_f( &
 
   end do
 
-end function qmckl_compute_een_rescaled_e_f
+end function qmckl_compute_een_rescaled_e_doc_f
     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_een_rescaled_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+#   #+CALL: generate_c_header(table=qmckl_factor_een_rescaled_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
     qmckl_exit_code qmckl_compute_een_rescaled_e (
-	  const qmckl_context context,
-	  const int64_t walk_num,
-	  const int64_t elec_num,
-	  const int64_t cord_num,
-	  const double rescale_factor_kappa_ee,
-	  const double* ee_distance,
-	  double* const een_rescaled_e );
+          const qmckl_context context,
+          const int64_t walk_num,
+          const int64_t elec_num,
+          const int64_t cord_num,
+          const double rescale_factor_kappa_ee,
+          const double* ee_distance,
+          double* const een_rescaled_e );
     #+end_src
 
-    #+CALL: generate_c_interface(table=qmckl_factor_een_rescaled_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+    #+CALL: generate_c_interface(table=qmckl_factor_een_rescaled_e_args,rettyp=get_value("CRetType"),fname="qmckl_compute_een_rescaled_e_doc")
 
     #+RESULTS:
     #+begin_src f90 :tangle (eval f) :comments org :exports none
-    integer(c_int32_t) function qmckl_compute_een_rescaled_e &
+    integer(c_int32_t) function qmckl_compute_een_rescaled_e_doc &
 	(context, walk_num, elec_num, cord_num, rescale_factor_kappa_ee, &
         ee_distance, een_rescaled_e) &
-	bind(C) result(info)
+    bind(C) result(info)
 
       use, intrinsic :: iso_c_binding
       implicit none
@@ -3400,12 +3522,185 @@ end function qmckl_compute_een_rescaled_e_f
       real    (c_double ) , intent(in)          :: ee_distance(elec_num,elec_num,walk_num)
       real    (c_double ) , intent(out)         :: een_rescaled_e(elec_num,elec_num,0:cord_num,walk_num)
 
-      integer(c_int32_t), external :: qmckl_compute_een_rescaled_e_f
-      info = qmckl_compute_een_rescaled_e_f &
+      integer(c_int32_t), external :: qmckl_compute_een_rescaled_e_doc_f
+      info = qmckl_compute_een_rescaled_e_doc_f &
 	     (context, walk_num, elec_num, cord_num, rescale_factor_kappa_ee, ee_distance, een_rescaled_e)
 
-    end function qmckl_compute_een_rescaled_e
+    end function qmckl_compute_een_rescaled_e_doc
     #+end_src
+
+    #+begin_src c :comments org :tangle (eval c) :noweb yes
+qmckl_exit_code qmckl_compute_een_rescaled_e_hpc (
+	  const qmckl_context context,
+	  const int64_t walk_num,
+	  const int64_t elec_num,
+	  const int64_t cord_num,
+	  const double rescale_factor_kappa_ee,
+	  const double* ee_distance,
+	  double* const een_rescaled_e ) {
+
+  double   *een_rescaled_e_ij;
+  double   x;
+  const int64_t   elec_pairs = (elec_num * (elec_num - 1)) / 2;
+  const int64_t   len_een_ij = elec_pairs * (cord_num + 1);
+  int64_t   k;
+
+  // number of element for the een_rescaled_e_ij[N_e*(N_e-1)/2][cord+1]
+  // probably in C is better [cord+1, Ne*(Ne-1)/2]
+  //elec_pairs = (elec_num * (elec_num - 1)) / 2;
+  //len_een_ij = elec_pairs * (cord_num + 1);
+  een_rescaled_e_ij = (double *) malloc (len_een_ij * sizeof(double));
+
+  if (context == QMCKL_NULL_CONTEXT) {
+     return QMCKL_INVALID_CONTEXT;
+  }
+
+  if (walk_num <= 0) {
+     return QMCKL_INVALID_ARG_2;
+  }
+
+  if (elec_num <= 0) {
+     return QMCKL_INVALID_ARG_3;
+  }
+
+  if (cord_num <= 0) {
+     return QMCKL_INVALID_ARG_4;
+  }
+
+  // Prepare table of exponentiated distances raised to appropriate power
+  // init
+
+  for (int kk = 0; kk < walk_num*(cord_num+1)*elec_num*elec_num; ++kk) {
+    een_rescaled_e[kk]= 0.0;
+  }
+
+  /*
+  for (int nw = 0; nw < walk_num; ++nw) {
+    for (int l = 0; l < (cord_num + 1); ++l) {
+      for (int i = 0; i < elec_num; ++i) {
+        for (int j = 0; j < elec_num; ++j) {
+          een_rescaled_e[j + i*elec_num + l*elec_num*elec_num + nw*(cord_num+1)*elec_num*elec_num]= 0.0;
+        }
+      }
+    }
+  }
+  */
+
+  for (int nw = 0; nw < walk_num; ++nw) {
+
+    for (int kk = 0; kk < len_een_ij; ++kk) {
+      // this array initialized at 0 except een_rescaled_e_ij(:, 1) = 1.0d0
+      // and the arrangement of indices is [cord_num+1, ne*(ne-1)/2]
+      een_rescaled_e_ij[kk]= ( kk < (elec_pairs) ? 1.0 : 0.0 );
+    }
+
+    k = 0;
+    for (int i = 0; i < elec_num; ++i) {
+      for (int j = 0; j < i; ++j) {
+        // een_rescaled_e_ij(k, 2) = dexp(-rescale_factor_kappa_ee * ee_distance(i, j, nw));
+        een_rescaled_e_ij[k + elec_pairs] = exp(-rescale_factor_kappa_ee * \
+                                    ee_distance[j + i*elec_num + nw*(elec_num*elec_num)]);
+        k = k + 1;
+      }
+    }
+
+
+    for (int l = 2; l < (cord_num+1); ++l) {
+      for (int k = 0; k < elec_pairs; ++k) {
+      // een_rescaled_e_ij(k, l + 1) = een_rescaled_e_ij(k, l + 1 - 1) * een_rescaled_e_ij(k, 2)
+        een_rescaled_e_ij[k+l*elec_pairs] = een_rescaled_e_ij[k + (l - 1)*elec_pairs] * \
+                                                  een_rescaled_e_ij[k + elec_pairs];
+      }
+    }
+
+
+  // prepare the actual een table
+  for (int i = 0; i < elec_num; ++i){
+    for (int j = 0; j < elec_num; ++j) {
+      een_rescaled_e[j + i*elec_num + 0 + nw*(cord_num+1)*elec_num*elec_num] = 1.0;
+    }
+  }
+
+    // Up to here it should work.
+  for ( int l = 1; l < (cord_num+1); ++l) {
+    k = 0;
+    for (int i = 0; i < elec_num; ++i) {
+      for (int j = 0; j < i; ++j) {
+        x = een_rescaled_e_ij[k + l*elec_pairs];
+        een_rescaled_e[j + i*elec_num + l*elec_num*elec_num + nw*elec_num*elec_num*(cord_num+1)] = x;
+        een_rescaled_e[i + j*elec_num + l*elec_num*elec_num + nw*elec_num*elec_num*(cord_num+1)] = x;
+        k = k + 1;
+      }
+    }
+  }
+
+  for (int l = 0; l < (cord_num + 1); ++l) {
+    for (int j = 0; j < elec_num; ++j) {
+      een_rescaled_e[j + j*elec_num + l*elec_num*elec_num + nw*elec_num*elec_num*(cord_num+1)] = 0.0;
+    }
+  }
+
+  }
+
+  free(een_rescaled_e_ij);
+
+  return QMCKL_SUCCESS;
+}
+    #+end_src
+
+#   #+CALL: generate_c_header(table=qmckl_factor_een_rescaled_e_args,rettyp=get_value("CRetType"),fname="qmckl_compute_een_rescaled_e_doc")
+
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
+    qmckl_exit_code qmckl_compute_een_rescaled_e (
+	  const qmckl_context context,
+	  const int64_t walk_num,
+	  const int64_t elec_num,
+	  const int64_t cord_num,
+	  const double rescale_factor_kappa_ee,
+	  const double* ee_distance,
+	  double* const een_rescaled_e );
+    #+end_src
+
+    #+begin_src c :tangle (eval h_private_func) :comments org
+    qmckl_exit_code qmckl_compute_een_rescaled_e_doc (
+	  const qmckl_context context,
+	  const int64_t walk_num,
+	  const int64_t elec_num,
+	  const int64_t cord_num,
+	  const double rescale_factor_kappa_ee,
+	  const double* ee_distance,
+	  double* const een_rescaled_e );
+    #+end_src
+
+    #+begin_src c :tangle (eval h_private_func) :comments org
+    qmckl_exit_code qmckl_compute_een_rescaled_e_hpc (
+	  const qmckl_context context,
+	  const int64_t walk_num,
+	  const int64_t elec_num,
+	  const int64_t cord_num,
+	  const double rescale_factor_kappa_ee,
+	  const double* ee_distance,
+	  double* const een_rescaled_e );
+    #+end_src
+
+    #+begin_src c :comments org :tangle (eval c) :noweb yes
+    qmckl_exit_code qmckl_compute_een_rescaled_e (
+	  const qmckl_context context,
+	  const int64_t walk_num,
+	  const int64_t elec_num,
+	  const int64_t cord_num,
+	  const double rescale_factor_kappa_ee,
+	  const double* ee_distance,
+	  double* const een_rescaled_e ) {
+
+    #ifdef HAVE_HPC
+    return qmckl_compute_een_rescaled_e_hpc(context, walk_num, elec_num, cord_num, rescale_factor_kappa_ee, ee_distance, een_rescaled_e);
+    #else
+    return qmckl_compute_een_rescaled_e_doc(context, walk_num, elec_num, cord_num, rescale_factor_kappa_ee, ee_distance, een_rescaled_e);
+    #endif
+    }
+    #+end_src
+
 
 *** Test
 
@@ -3481,7 +3776,6 @@ assert(fabs(een_rescaled_e[0][1][0][4]-0.01754273169464735)   < 1.e-12);
 assert(fabs(een_rescaled_e[0][2][1][3]-0.02214680362033448)   < 1.e-12);
 assert(fabs(een_rescaled_e[0][2][1][4]-0.0005700154999202759) < 1.e-12);
 assert(fabs(een_rescaled_e[0][2][1][5]-0.3424402276009091)    < 1.e-12);
-
      #+end_src
 
 ** Electron-electron rescaled distances for each order and derivatives
@@ -3597,7 +3891,7 @@ qmckl_exit_code qmckl_provide_een_rescaled_e_deriv_e(qmckl_context context)
 
 *** Compute
    :PROPERTIES:
-   :Name:     qmckl_compute_een_rescaled_e_deriv_e
+   :Name:     qmckl_compute_factor_een_rescaled_e_deriv_e
    :CRetType: qmckl_exit_code
    :FRetType: qmckl_exit_code
    :END:
@@ -3704,21 +3998,20 @@ integer function qmckl_compute_factor_een_rescaled_e_deriv_e_f( &
 end function qmckl_compute_factor_een_rescaled_e_deriv_e_f
     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_een_rescaled_e_deriv_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+#  #+CALL: generate_c_header(table=qmckl_factor_een_rescaled_e_deriv_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
-    qmckl_exit_code qmckl_compute_factor_een_rescaled_e_deriv_e (
-	  const qmckl_context context,
-	  const int64_t walk_num,
-	  const int64_t elec_num,
-	  const int64_t cord_num,
-	  const double rescale_factor_kappa_ee,
-	  const double* coord_new,
-	  const double* ee_distance,
-	  const double* een_rescaled_e,
-	  double* const een_rescaled_e_deriv_e );
-    #+end_src
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
+   qmckl_exit_code qmckl_compute_factor_een_rescaled_e_deriv_e (
+         const qmckl_context context,
+         const int64_t walk_num,
+         const int64_t elec_num,
+         const int64_t cord_num,
+         const double rescale_factor_kappa_ee,
+         const double* coord_new,
+         const double* ee_distance,
+         const double* een_rescaled_e,
+         double* const een_rescaled_e_deriv_e );
+   #+end_src
 
 
     #+CALL: generate_c_interface(table=qmckl_factor_een_rescaled_e_deriv_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
@@ -3726,16 +4019,16 @@ end function qmckl_compute_factor_een_rescaled_e_deriv_e_f
     #+RESULTS:
     #+begin_src f90 :tangle (eval f) :comments org :exports none
     integer(c_int32_t) function qmckl_compute_factor_een_rescaled_e_deriv_e &
-	(context, &
-		 walk_num, &
-		 elec_num, &
-		 cord_num, &
-		 rescale_factor_kappa_ee, &
-		 coord_new, &
-		 ee_distance, &
-		 een_rescaled_e, &
-		 een_rescaled_e_deriv_e) &
-	bind(C) result(info)
+        (context, &
+         walk_num, &
+         elec_num, &
+         cord_num, &
+         rescale_factor_kappa_ee, &
+         coord_new, &
+         ee_distance, &
+         een_rescaled_e, &
+         een_rescaled_e_deriv_e) &
+        bind(C) result(info)
 
       use, intrinsic :: iso_c_binding
       implicit none
@@ -3752,15 +4045,15 @@ end function qmckl_compute_factor_een_rescaled_e_deriv_e_f
 
       integer(c_int32_t), external :: qmckl_compute_factor_een_rescaled_e_deriv_e_f
       info = qmckl_compute_factor_een_rescaled_e_deriv_e_f &
-	     (context, &
-		 walk_num, &
-		 elec_num, &
-		 cord_num, &
-		 rescale_factor_kappa_ee, &
-		 coord_new, &
-		 ee_distance, &
-		 een_rescaled_e, &
-		 een_rescaled_e_deriv_e)
+             (context, &
+         walk_num, &
+         elec_num, &
+         cord_num, &
+         rescale_factor_kappa_ee, &
+         coord_new, &
+         ee_distance, &
+         een_rescaled_e, &
+         een_rescaled_e_deriv_e)
 
     end function qmckl_compute_factor_een_rescaled_e_deriv_e
     #+end_src
@@ -4064,19 +4357,19 @@ end function qmckl_compute_een_rescaled_n_f
 
     #+begin_src c :comments org :tangle (eval c) :noweb yes
 qmckl_exit_code qmckl_compute_een_rescaled_n (
-	  const qmckl_context context,
-	  const int64_t walk_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t cord_num,
-	  const double rescale_factor_kappa_en,
-	  const double* en_distance,
-	  double* const een_rescaled_n ) {
+      const qmckl_context context,
+      const int64_t walk_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t cord_num,
+      const double rescale_factor_kappa_en,
+      const double* en_distance,
+      double* const een_rescaled_n ) {
 
 
   if (context == QMCKL_NULL_CONTEXT) {
     return QMCKL_INVALID_CONTEXT;
-  } 
+  }
 
   if (walk_num <= 0) {
     return QMCKL_INVALID_ARG_2;
@@ -4126,19 +4419,18 @@ qmckl_exit_code qmckl_compute_een_rescaled_n (
 }
     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_een_rescaled_n_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+#   #+CALL: generate_c_header(table=qmckl_factor_een_rescaled_n_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
     qmckl_exit_code qmckl_compute_een_rescaled_n (
-	  const qmckl_context context,
-	  const int64_t walk_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t cord_num,
-	  const double rescale_factor_kappa_en,
-	  const double* en_distance,
-	  double* const een_rescaled_n );
+          const qmckl_context context,
+          const int64_t walk_num,
+          const int64_t elec_num,
+          const int64_t nucl_num,
+          const int64_t cord_num,
+          const double rescale_factor_kappa_en,
+          const double* en_distance,
+          double* const een_rescaled_n );
     #+end_src
 
 *** Test
@@ -4433,22 +4725,21 @@ integer function qmckl_compute_factor_een_rescaled_n_deriv_e_f( &
 end function qmckl_compute_factor_een_rescaled_n_deriv_e_f
     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_compute_factor_een_rescaled_n_deriv_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+#   #+CALL: generate_c_header(table=qmckl_compute_factor_een_rescaled_n_deriv_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
     qmckl_exit_code qmckl_compute_factor_een_rescaled_n_deriv_e (
-	  const qmckl_context context,
-	  const int64_t walk_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t cord_num,
-	  const double rescale_factor_kappa_en,
-	  const double* coord_new,
-	  const double* coord,
-	  const double* en_distance,
-	  const double* een_rescaled_n,
-	  double* const een_rescaled_n_deriv_e );
+          const qmckl_context context,
+          const int64_t walk_num,
+          const int64_t elec_num,
+          const int64_t nucl_num,
+          const int64_t cord_num,
+          const double rescale_factor_kappa_en,
+          const double* coord_new,
+          const double* coord,
+          const double* en_distance,
+          const double* een_rescaled_n,
+          double* const een_rescaled_n_deriv_e );
     #+end_src
 
     #+CALL: generate_c_interface(table=qmckl_compute_factor_een_rescaled_n_deriv_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
@@ -4456,18 +4747,18 @@ end function qmckl_compute_factor_een_rescaled_n_deriv_e_f
     #+RESULTS:
     #+begin_src f90 :tangle (eval f) :comments org :exports none
     integer(c_int32_t) function qmckl_compute_factor_een_rescaled_n_deriv_e &
-	(context, &
-		 walk_num, &
-		 elec_num, &
-		 nucl_num, &
-		 cord_num, &
-		 rescale_factor_kappa_en, &
-		 coord_new, &
-		 coord, &
-		 en_distance, &
-		 een_rescaled_n, &
-		 een_rescaled_n_deriv_e) &
-	bind(C) result(info)
+        (context, &
+         walk_num, &
+         elec_num, &
+         nucl_num, &
+         cord_num, &
+         rescale_factor_kappa_en, &
+         coord_new, &
+         coord, &
+         en_distance, &
+         een_rescaled_n, &
+         een_rescaled_n_deriv_e) &
+        bind(C) result(info)
 
       use, intrinsic :: iso_c_binding
       implicit none
@@ -4481,22 +4772,22 @@ end function qmckl_compute_factor_een_rescaled_n_deriv_e_f
       real    (c_double ) , intent(in)          :: coord_new(elec_num,3,walk_num)
       real    (c_double ) , intent(in)          :: coord(nucl_num,3)
       real    (c_double ) , intent(in)          :: en_distance(nucl_num,elec_num,walk_num)
-      real    (c_double ) , intent(in)          :: een_rescaled_n(0:cord_num,nucl_num,elec_num,walk_num)
+      real    (c_double ) , intent(in)          :: een_rescaled_n(elec_num,nucl_num,0:cord_num,walk_num)
       real    (c_double ) , intent(out)         :: een_rescaled_n_deriv_e(elec_num,4,nucl_num,0:cord_num,walk_num)
 
       integer(c_int32_t), external :: qmckl_compute_factor_een_rescaled_n_deriv_e_f
       info = qmckl_compute_factor_een_rescaled_n_deriv_e_f &
-	     (context, &
-		 walk_num, &
-		 elec_num, &
-		 nucl_num, &
-		 cord_num, &
-		 rescale_factor_kappa_en, &
-		 coord_new, &
-		 coord, &
-		 en_distance, &
-		 een_rescaled_n, &
-		 een_rescaled_n_deriv_e)
+             (context, &
+         walk_num, &
+         elec_num, &
+         nucl_num, &
+         cord_num, &
+         rescale_factor_kappa_en, &
+         coord_new, &
+         coord, &
+         en_distance, &
+         een_rescaled_n, &
+         een_rescaled_n_deriv_e)
 
     end function qmckl_compute_factor_een_rescaled_n_deriv_e
     #+end_src
@@ -4890,64 +5181,56 @@ qmckl_exit_code qmckl_provide_tmp_c(qmckl_context context)
       ctx->jastrow.tmp_c = tmp_c;
     }
 
-    /* Choose the correct compute function (depending on offload type) */
-    switch(ctx->jastrow.offload_type) {
-      case OFFLOAD_OPENACC:
-        #ifdef HAVE_OPENACC_OFFLOAD
-          rc =
-          qmckl_compute_tmp_c_acc_offload(context,
-                                 ctx->jastrow.cord_num,
-                                 ctx->electron.num,
-                                 ctx->nucleus.num,
-                                 ctx->electron.walk_num,
-                                 ctx->jastrow.een_rescaled_e,
-                                 ctx->jastrow.een_rescaled_n,
-                                 ctx->jastrow.tmp_c);
-        #else
-          rc = qmckl_compute_tmp_c(context,
-                                 ctx->jastrow.cord_num,
-                                 ctx->electron.num,
-                                 ctx->nucleus.num,
-                                 ctx->electron.walk_num,
-                                 ctx->jastrow.een_rescaled_e,
-                                 ctx->jastrow.een_rescaled_n,
-                                 ctx->jastrow.tmp_c);
 
-        #endif
-		  break;
-      case OFFLOAD_CUBLAS:
-        #ifdef HAVE_CUBLAS_OFFLOAD
-          rc =
-          qmckl_compute_tmp_c_cublas_offload(context,
-                                ctx->jastrow.cord_num,
-                                ctx->electron.num,
-                                ctx->nucleus.num,
-                                ctx->electron.walk_num,
-                                ctx->jastrow.een_rescaled_e,
-                                ctx->jastrow.een_rescaled_n,
-                                ctx->jastrow.tmp_c);
-        #else
-          rc = qmckl_compute_tmp_c(context,
-                                ctx->jastrow.cord_num,
-                                ctx->electron.num,
-                                ctx->nucleus.num,
-                                ctx->electron.walk_num,
-                                ctx->jastrow.een_rescaled_e,
-                                ctx->jastrow.een_rescaled_n,
-                                ctx->jastrow.tmp_c);
-        #endif
-		  break;
-      default:
-        rc = qmckl_compute_tmp_c(context,
-                                 ctx->jastrow.cord_num,
-                                 ctx->electron.num,
-                                 ctx->nucleus.num,
-                                 ctx->electron.walk_num,
-                                 ctx->jastrow.een_rescaled_e,
-                                 ctx->jastrow.een_rescaled_n,
-                                 ctx->jastrow.tmp_c);
-		break;
+    /* Choose the correct compute function (depending on offload type) */
+#ifdef HAVE_HPC
+    const bool gpu_offload = ctx->jastrow.gpu_offload;
+#else
+    const bool gpu_offload = false;
+#endif
+
+    if (gpu_offload) {
+#ifdef HAVE_CUBLAS_OFFLOAD
+      rc = qmckl_compute_tmp_c_cublas_offload(context,
+                                              ctx->jastrow.cord_num,
+                                              ctx->electron.num,
+                                              ctx->nucleus.num,
+                                              ctx->electron.walk_num,
+                                              ctx->jastrow.een_rescaled_e,
+                                              ctx->jastrow.een_rescaled_n,
+                                              ctx->jastrow.tmp_c);
+#elif HAVE_OPENACC_OFFLOAD
+      rc = qmckl_compute_tmp_c_acc_offload(context,
+                                           ctx->jastrow.cord_num,
+                                           ctx->electron.num,
+                                           ctx->nucleus.num,
+                                           ctx->electron.walk_num,
+                                           ctx->jastrow.een_rescaled_e,
+                                           ctx->jastrow.een_rescaled_n,
+                                           ctx->jastrow.tmp_c);
+#elif HAVE_OPENMP_OFFLOAD
+      rc = qmckl_compute_tmp_c_omp_offload(context,
+                                           ctx->jastrow.cord_num,
+                                           ctx->electron.num,
+                                           ctx->nucleus.num,
+                                           ctx->electron.walk_num,
+                                           ctx->jastrow.een_rescaled_e,
+                                           ctx->jastrow.een_rescaled_n,
+                                           ctx->jastrow.tmp_c);
+#else
+      rc = QMCKL_FAILURE;
+#endif
+    } else {
+      rc = qmckl_compute_tmp_c(context,
+                               ctx->jastrow.cord_num,
+                               ctx->electron.num,
+                               ctx->nucleus.num,
+                               ctx->electron.walk_num,
+                               ctx->jastrow.een_rescaled_e,
+                               ctx->jastrow.een_rescaled_n,
+                               ctx->jastrow.tmp_c);
     }
+
 
     ctx->jastrow.tmp_c_date = ctx->date;
   }
@@ -4988,18 +5271,45 @@ qmckl_exit_code qmckl_provide_dtmp_c(qmckl_context context)
       ctx->jastrow.dtmp_c = dtmp_c;
     }
 
-    switch(ctx->jastrow.offload_type) {
-      case OFFLOAD_OPENACC:
-        #ifdef HAVE_OPENACC_OFFLOAD
-         rc = qmckl_compute_dtmp_c_acc_offload(context,
-                                ctx->jastrow.cord_num,
-                                ctx->electron.num,
-                                ctx->nucleus.num,
-                                ctx->electron.walk_num,
-                                ctx->jastrow.een_rescaled_e_deriv_e,
-                                ctx->jastrow.een_rescaled_n,
-                                ctx->jastrow.dtmp_c);
-        #else
+
+#ifdef HAVE_HPC
+    const bool gpu_offload = ctx->jastrow.gpu_offload;
+#else
+    const bool gpu_offload = false;
+#endif
+
+    if (gpu_offload) {
+#ifdef HAVE_CUBLAS_OFFLOAD
+      rc = qmckl_compute_dtmp_c_cublas_offload(context,
+                                            ctx->jastrow.cord_num,
+                                            ctx->electron.num,
+                                            ctx->nucleus.num,
+                                            ctx->electron.walk_num,
+                                            ctx->jastrow.een_rescaled_e_deriv_e,
+                                            ctx->jastrow.een_rescaled_n,
+                                            ctx->jastrow.dtmp_c);
+#elif HAVE_OPENACC_OFFLOAD
+      rc = qmckl_compute_dtmp_c_acc_offload(context,
+                                            ctx->jastrow.cord_num,
+                                            ctx->electron.num,
+                                            ctx->nucleus.num,
+                                            ctx->electron.walk_num,
+                                            ctx->jastrow.een_rescaled_e_deriv_e,
+                                            ctx->jastrow.een_rescaled_n,
+                                            ctx->jastrow.dtmp_c);
+#elif HAVE_OPENMP_OFFLOAD
+      rc = qmckl_compute_dtmp_c_omp_offload(context,
+                                            ctx->jastrow.cord_num,
+                                            ctx->electron.num,
+                                            ctx->nucleus.num,
+                                            ctx->electron.walk_num,
+                                            ctx->jastrow.een_rescaled_e_deriv_e,
+                                            ctx->jastrow.een_rescaled_n,
+                                            ctx->jastrow.dtmp_c);
+#else
+      rc = QMCKL_FAILURE;
+#endif
+    } else {
         rc = qmckl_compute_dtmp_c(context,
                                 ctx->jastrow.cord_num,
                                 ctx->electron.num,
@@ -5008,44 +5318,12 @@ qmckl_exit_code qmckl_provide_dtmp_c(qmckl_context context)
                                 ctx->jastrow.een_rescaled_e_deriv_e,
                                 ctx->jastrow.een_rescaled_n,
                                 ctx->jastrow.dtmp_c);
-        #endif
-		  break;
-      case OFFLOAD_CUBLAS:
-        #ifdef HAVE_CUBLAS_OFFLOAD
-          rc = qmckl_compute_dtmp_c_acc_offload(context,
-                                ctx->jastrow.cord_num,
-                                ctx->electron.num,
-                                ctx->nucleus.num,
-                                ctx->electron.walk_num,
-                                ctx->jastrow.een_rescaled_e_deriv_e,
-                                ctx->jastrow.een_rescaled_n,
-                                ctx->jastrow.dtmp_c);
-       #else
-        rc = qmckl_compute_dtmp_c(context,
-                                ctx->jastrow.cord_num,
-                                ctx->electron.num,
-                                ctx->nucleus.num,
-                                ctx->electron.walk_num,
-                                ctx->jastrow.een_rescaled_e_deriv_e,
-                                ctx->jastrow.een_rescaled_n,
-                                ctx->jastrow.dtmp_c);
-        #endif
-		  break;
-      default:
-        rc = qmckl_compute_dtmp_c(context,
-                                ctx->jastrow.cord_num,
-                                ctx->electron.num,
-                                ctx->nucleus.num,
-                                ctx->electron.walk_num,
-                                ctx->jastrow.een_rescaled_e_deriv_e,
-                                ctx->jastrow.een_rescaled_n,
-                                ctx->jastrow.dtmp_c);
-		  break;
     }
 
     if (rc != QMCKL_SUCCESS) {
       return rc;
     }
+
 
     ctx->jastrow.dtmp_c_date = ctx->date;
   }
@@ -5113,13 +5391,13 @@ end function qmckl_compute_dim_cord_vect_f
 
     #+begin_src c :comments org :tangle (eval c) :noweb yes
 qmckl_exit_code qmckl_compute_dim_cord_vect (
-	  const qmckl_context context,
-	  const int64_t cord_num,
-	  int64_t* const dim_cord_vect){
-  
+      const qmckl_context context,
+      const int64_t cord_num,
+      int64_t* const dim_cord_vect){
+
   int         lmax;
 
-  
+
   if (context == QMCKL_NULL_CONTEXT) {
     return QMCKL_INVALID_CONTEXT;
   }
@@ -5129,7 +5407,7 @@ qmckl_exit_code qmckl_compute_dim_cord_vect (
   }
 
   *dim_cord_vect = 0;
- 
+
   for (int p=2; p <= cord_num; ++p){
     for (int k=p-1; k >= 0; --k) {
       if (k != 0) {
@@ -5143,19 +5421,18 @@ qmckl_exit_code qmckl_compute_dim_cord_vect (
       }
     }
   }
-  
+
   return QMCKL_SUCCESS;
 }
     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_dim_cord_vect_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+#   #+CALL: generate_c_header(table=qmckl_factor_dim_cord_vect_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
     qmckl_exit_code qmckl_compute_dim_cord_vect (
-	  const qmckl_context context,
-	  const int64_t cord_num,
-	  int64_t* const dim_cord_vect );
+          const qmckl_context context,
+          const int64_t cord_num,
+          int64_t* const dim_cord_vect );
     #+end_src
 
 
@@ -5178,7 +5455,7 @@ qmckl_exit_code qmckl_compute_dim_cord_vect (
     | ~cord_vect_full~   | ~double[dim_cord_vect][nucl_num]~      | out    | Full list of coefficients    |
 
     #+begin_src f90 :comments org :tangle (eval f) :noweb yes
-integer function qmckl_compute_cord_vect_full_f( &
+integer function qmckl_compute_cord_vect_full_doc_f( &
      context, nucl_num, dim_cord_vect, type_nucl_num,  &
      type_nucl_vector, cord_vector, cord_vect_full) &
      result(info)
@@ -5221,29 +5498,14 @@ integer function qmckl_compute_cord_vect_full_f( &
     cord_vect_full(a,1:dim_cord_vect) = cord_vector(type_nucl_vector(a),1:dim_cord_vect)
   end do
 
-end function qmckl_compute_cord_vect_full_f
+end function qmckl_compute_cord_vect_full_doc_f
     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_cord_vect_full_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
-
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
-    qmckl_exit_code qmckl_compute_cord_vect_full (
-	  const qmckl_context context,
-	  const int64_t nucl_num,
-	  const int64_t dim_cord_vect,
-	  const int64_t type_nucl_num,
-	  const int64_t* type_nucl_vector,
-	  const double* cord_vector,
-	  double* const cord_vect_full );
-    #+end_src
-
-
-    #+CALL: generate_c_interface(table=qmckl_factor_cord_vect_full_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+    #+CALL: generate_c_interface(table=qmckl_factor_cord_vect_full_args,rettyp=get_value("CRetType"),fname="qmckl_compute_cord_vect_full_doc")
 
     #+RESULTS:
     #+begin_src f90 :tangle (eval f) :comments org :exports none
-    integer(c_int32_t) function qmckl_compute_cord_vect_full &
+    integer(c_int32_t) function qmckl_compute_cord_vect_full_doc &
 	(context, nucl_num, dim_cord_vect, type_nucl_num, type_nucl_vector, cord_vector, cord_vect_full) &
 	bind(C) result(info)
 
@@ -5258,12 +5520,104 @@ end function qmckl_compute_cord_vect_full_f
       real    (c_double ) , intent(in)          :: cord_vector(type_nucl_num,dim_cord_vect)
       real    (c_double ) , intent(out)         :: cord_vect_full(nucl_num,dim_cord_vect)
 
-      integer(c_int32_t), external :: qmckl_compute_cord_vect_full_f
-      info = qmckl_compute_cord_vect_full_f &
+      integer(c_int32_t), external :: qmckl_compute_cord_vect_full_doc_f
+      info = qmckl_compute_cord_vect_full_doc_f &
 	     (context, nucl_num, dim_cord_vect, type_nucl_num, type_nucl_vector, cord_vector, cord_vect_full)
 
-    end function qmckl_compute_cord_vect_full
+    end function qmckl_compute_cord_vect_full_doc
     #+end_src
+
+    #+begin_src c :comments org :tangle (eval c) :noweb yes
+qmckl_exit_code qmckl_compute_cord_vect_full_hpc (
+	  const qmckl_context context,
+	  const int64_t nucl_num,
+	  const int64_t dim_cord_vect,
+	  const int64_t type_nucl_num,
+	  const int64_t* type_nucl_vector,
+	  const double* cord_vector,
+	  double* const cord_vect_full ) {
+
+  if (context == QMCKL_NULL_CONTEXT) {
+     return QMCKL_INVALID_CONTEXT;
+  }
+
+  if (nucl_num <= 0) {
+     return QMCKL_INVALID_ARG_2;
+  }
+
+  if (type_nucl_num <= 0) {
+     return QMCKL_INVALID_ARG_4;
+  }
+
+  if (dim_cord_vect <= 0) {
+     return QMCKL_INVALID_ARG_5;
+  }
+
+  for (int i=0; i < dim_cord_vect; ++i) {
+    for (int a=0; a < nucl_num; ++a){
+      cord_vect_full[a + i*nucl_num] = cord_vector[(type_nucl_vector[a]-1)+i*type_nucl_num];
+    }
+  }
+
+  return QMCKL_SUCCESS;
+  }
+    #+end_src
+
+
+#   #+CALL: generate_c_header(table=qmckl_factor_cord_vect_full_args,rettyp=get_value("CRetType"),fname="qmckl_compute_cord_vect_full_doc")
+
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
+    qmckl_exit_code qmckl_compute_cord_vect_full (
+	  const qmckl_context context,
+	  const int64_t nucl_num,
+	  const int64_t dim_cord_vect,
+	  const int64_t type_nucl_num,
+	  const int64_t* type_nucl_vector,
+	  const double* cord_vector,
+	  double* const cord_vect_full );
+    #+end_src
+
+    #+begin_src c :tangle (eval h_private_func) :comments org
+    qmckl_exit_code qmckl_compute_cord_vect_full_doc (
+	  const qmckl_context context,
+	  const int64_t nucl_num,
+	  const int64_t dim_cord_vect,
+	  const int64_t type_nucl_num,
+	  const int64_t* type_nucl_vector,
+	  const double* cord_vector,
+	  double* const cord_vect_full );
+    #+end_src
+
+    #+begin_src c :tangle (eval h_private_func) :comments org
+    qmckl_exit_code qmckl_compute_cord_vect_full_hpc (
+	  const qmckl_context context,
+	  const int64_t nucl_num,
+	  const int64_t dim_cord_vect,
+	  const int64_t type_nucl_num,
+	  const int64_t* type_nucl_vector,
+	  const double* cord_vector,
+	  double* const cord_vect_full );
+    #+end_src
+
+    #+begin_src c :comments org :tangle (eval c) :noweb yes
+qmckl_exit_code qmckl_compute_cord_vect_full (
+	  const qmckl_context context,
+	  const int64_t nucl_num,
+	  const int64_t dim_cord_vect,
+	  const int64_t type_nucl_num,
+	  const int64_t* type_nucl_vector,
+	  const double* cord_vector,
+	  double* const cord_vect_full ) {
+
+    #ifdef HAVE_HPC
+      return qmckl_compute_cord_vect_full_hpc(context, nucl_num, dim_cord_vect, type_nucl_num, type_nucl_vector, cord_vector, cord_vect_full);
+    #else
+      return qmckl_compute_cord_vect_full_doc(context, nucl_num, dim_cord_vect, type_nucl_num, type_nucl_vector, cord_vector, cord_vect_full);
+    #endif
+    }
+    #+end_src
+
+
 
 *** Compute lkpm_combined_index
    :PROPERTIES:
@@ -5336,22 +5690,22 @@ end function qmckl_compute_lkpm_combined_index_f
 
     #+begin_src c :comments org :tangle (eval c) :noweb yes
 qmckl_exit_code qmckl_compute_lkpm_combined_index (
-	  const qmckl_context context,
-	  const int64_t cord_num,
-	  const int64_t dim_cord_vect,
-	  int64_t* const lkpm_combined_index ) {
+      const qmckl_context context,
+      const int64_t cord_num,
+      const int64_t dim_cord_vect,
+      int64_t* const lkpm_combined_index ) {
 
   int kk, lmax, m;
 
-  if (context == QMCKL_NULL_CONTEXT) { 
+  if (context == QMCKL_NULL_CONTEXT) {
      return QMCKL_INVALID_CONTEXT;
   }
 
-  if (cord_num <= 0) { 
+  if (cord_num <= 0) {
      return QMCKL_INVALID_ARG_2;
   }
 
-  if (dim_cord_vect <= 0) { 
+  if (dim_cord_vect <= 0) {
      return QMCKL_INVALID_ARG_3;
   }
 
@@ -5381,15 +5735,14 @@ qmckl_exit_code qmckl_compute_lkpm_combined_index (
 }
     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_lkpm_combined_index_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+#   #+CALL: generate_c_header(table=qmckl_factor_lkpm_combined_index_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
     qmckl_exit_code qmckl_compute_lkpm_combined_index (
-	  const qmckl_context context,
-	  const int64_t cord_num,
-	  const int64_t dim_cord_vect,
-	  int64_t* const lkpm_combined_index );
+          const qmckl_context context,
+          const int64_t cord_num,
+          const int64_t dim_cord_vect,
+          int64_t* const lkpm_combined_index );
     #+end_src
 
 
@@ -5412,6 +5765,38 @@ qmckl_exit_code qmckl_compute_lkpm_combined_index (
     | ~een_rescaled_e~ | ~double[walk_num][0:cord_num][elec_num][elec_num]~               | in     | Electron-electron rescaled factor |
     | ~een_rescaled_n~ | ~double[walk_num][0:cord_num][nucl_num][elec_num]~               | in     | Electron-nucleus rescaled factor  |
     | ~tmp_c~          | ~double[walk_num][0:cord_num-1][0:cord_num][nucl_num][elec_num]~ | out    | vector of non-zero coefficients   |
+
+    #+begin_src c :comments org :tangle (eval c) :noweb yes
+qmckl_exit_code qmckl_compute_tmp_c (const qmckl_context context,
+                                     const int64_t cord_num,
+                                     const int64_t elec_num,
+                                     const int64_t nucl_num,
+                                     const int64_t walk_num,
+                                     const double* een_rescaled_e,
+                                     const double* een_rescaled_n,
+                                     double* const tmp_c )
+{
+#ifdef HAVE_HPC
+  return qmckl_compute_tmp_c_hpc(context, cord_num, elec_num, nucl_num, walk_num, een_rescaled_e, een_rescaled_n, tmp_c);
+#else
+  return qmckl_compute_tmp_c_doc(context, cord_num, elec_num, nucl_num, walk_num, een_rescaled_e, een_rescaled_n, tmp_c);
+#endif
+}
+    #+end_src
+
+#   #+CALL: generate_c_header(table=qmckl_factor_tmp_c_args,rettyp=get_value("CRetType"),fname="qmckl_compute_tmp_c")
+
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
+    qmckl_exit_code qmckl_compute_tmp_c (
+          const qmckl_context context,
+          const int64_t cord_num,
+          const int64_t elec_num,
+          const int64_t nucl_num,
+          const int64_t walk_num,
+          const double* een_rescaled_e,
+          const double* een_rescaled_n,
+          double* const tmp_c );
+    #+end_src
 
     #+begin_src f90 :comments org :tangle (eval f) :noweb yes
 integer function qmckl_compute_tmp_c_doc_f( &
@@ -5481,7 +5866,19 @@ integer function qmckl_compute_tmp_c_doc_f( &
 end function qmckl_compute_tmp_c_doc_f
     #+end_src
 
-#+CALL: generate_c_interface(table=qmckl_factor_tmp_c_args,rettyp=get_value("FRetType"),fname="qmckl_compute_tmp_c_doc")
+    #+begin_src c :tangle (eval h_private_func) :comments org
+qmckl_exit_code qmckl_compute_tmp_c_doc (
+          const qmckl_context context,
+          const int64_t cord_num,
+          const int64_t elec_num,
+          const int64_t nucl_num,
+          const int64_t walk_num,
+          const double* een_rescaled_e,
+          const double* een_rescaled_n,
+          double* const tmp_c );
+    #+end_src
+
+    #+CALL: generate_c_interface(table=qmckl_factor_tmp_c_args,rettyp=get_value("FRetType"),fname="qmckl_compute_tmp_c_doc")
 
 #+RESULTS:
 #+begin_src f90 :tangle (eval f) :comments org :exports none
@@ -5508,17 +5905,18 @@ integer(c_int32_t) function qmckl_compute_tmp_c_doc &
 end function qmckl_compute_tmp_c_doc
 #+end_src
 
+**** CPU                                                           :noexport:
 
     #+begin_src c :comments org :tangle (eval c) :noweb yes
 qmckl_exit_code qmckl_compute_tmp_c_hpc (
-	  const qmckl_context context,
-	  const int64_t cord_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t walk_num,
-	  const double* een_rescaled_e,
-	  const double* een_rescaled_n,
-	  double* const tmp_c ) {
+      const qmckl_context context,
+      const int64_t cord_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t walk_num,
+      const double* een_rescaled_e,
+      const double* een_rescaled_n,
+      double* const tmp_c ) {
 
   if (context == QMCKL_NULL_CONTEXT) {
     return QMCKL_INVALID_CONTEXT;
@@ -5526,19 +5924,19 @@ qmckl_exit_code qmckl_compute_tmp_c_hpc (
 
   if (cord_num <= 0) {
     return QMCKL_INVALID_ARG_2;
-  } 
+  }
 
   if (elec_num <= 0) {
     return QMCKL_INVALID_ARG_3;
-  } 
+  }
 
   if (nucl_num <= 0) {
     return QMCKL_INVALID_ARG_4;
-  } 
+  }
 
   if (walk_num <= 0) {
     return QMCKL_INVALID_ARG_5;
-  } 
+  }
 
   qmckl_exit_code info = QMCKL_SUCCESS;
 
@@ -5559,22 +5957,23 @@ qmckl_exit_code qmckl_compute_tmp_c_hpc (
   const int64_t bf = elec_num*nucl_num*(cord_num+1);
   const int64_t cf = bf;
 
+#ifdef HAVE_OPENMP
+#pragma omp parallel for collapse(2)
+#endif
   for (int64_t nw=0; nw < walk_num; ++nw) {
     for (int64_t i=0; i<cord_num; ++i){
-    info = qmckl_dgemm(context, TransA, TransB, M, N, K, alpha,     \
-                       &(een_rescaled_e[af*(i+nw*(cord_num+1))]), \
-                       LDA,                                        \
-                       &(een_rescaled_n[bf*nw]), \
-                       LDB,                                        \
-                       beta,                                       \
-                       &(tmp_c[cf*(i+nw*cord_num)]), \
-                       LDC);
+      info = qmckl_dgemm(context, TransA, TransB, M, N, K, alpha,
+                         &(een_rescaled_e[af*(i+nw*(cord_num+1))]), LDA,
+                         &(een_rescaled_n[bf*nw]), LDB, beta,
+                         &(tmp_c[cf*(i+nw*cord_num)]), LDC);
     }
   }
 
   return info;
 }
     #+end_src
+
+
 
     #+CALL: generate_c_header(table=qmckl_factor_tmp_c_args,rettyp=get_value("CRetType"),fname="qmckl_compute_tmp_c")
 
@@ -5588,7 +5987,7 @@ qmckl_exit_code qmckl_compute_tmp_c (
           const int64_t walk_num,
           const double* een_rescaled_e,
           const double* een_rescaled_n,
-          double* const tmp_c ); 
+          double* const tmp_c );
     #+end_src
 
 #   #+CALL: generate_c_header(table=qmckl_factor_tmp_c_args,rettyp=get_value("CRetType"),fname="qmckl_compute_tmp_c_doc")
@@ -5603,12 +6002,13 @@ qmckl_exit_code qmckl_compute_tmp_c_doc (
           const int64_t walk_num,
           const double* een_rescaled_e,
           const double* een_rescaled_n,
-          double* const tmp_c ); 
+          double* const tmp_c );
     #+end_src
 
 #   #+CALL: generate_c_header(table=qmckl_factor_tmp_c_args,rettyp=get_value("CRetType"),fname="qmckl_compute_tmp_c_hpc")
 
     #+RESULTS:
+
     #+begin_src c :tangle (eval h_private_func) :comments org
 qmckl_exit_code qmckl_compute_tmp_c_hpc (const qmckl_context context,
                                          const int64_t cord_num,
@@ -5617,59 +6017,23 @@ qmckl_exit_code qmckl_compute_tmp_c_hpc (const qmckl_context context,
                                          const int64_t walk_num,
                                          const double* een_rescaled_e,
                                          const double* een_rescaled_n,
-                                         double* const tmp_c ); 
+                                         double* const tmp_c );
     #+end_src
 
+**** OpenACC offload                                               :noexport:
 
-    #+begin_src c :comments org :tangle (eval c) :noweb yes
-qmckl_exit_code qmckl_compute_tmp_c (const qmckl_context context,
-                                     const int64_t cord_num,
-                                     const int64_t elec_num,
-                                     const int64_t nucl_num,
-                                     const int64_t walk_num,
-                                     const double* een_rescaled_e,
-                                     const double* een_rescaled_n,
-                                     double* const tmp_c )
-{
-#ifdef HAVE_HPC
-  return qmckl_compute_tmp_c_hpc(context, cord_num, elec_num, nucl_num, walk_num, een_rescaled_e, een_rescaled_n, tmp_c);
-#else
-  return qmckl_compute_tmp_c_doc(context, cord_num, elec_num, nucl_num, walk_num, een_rescaled_e, een_rescaled_n, tmp_c);
-#endif
-}
-    #+end_src
-    
-*** Compute tmp_c (OpenACC offload)
-   :PROPERTIES:
-   :Name:     qmckl_compute_tmp_c_acc_offload
-   :CRetType: qmckl_exit_code
-   :FRetType: qmckl_exit_code
-   :END:
-
-    #+NAME: qmckl_factor_tmp_c_acc_offload_args
-    | Variable         | Type                                                             | In/Out | Description                       |
-    |------------------+------------------------------------------------------------------+--------+-----------------------------------|
-    | ~context~        | ~qmckl_context~                                                  | in     | Global state                      |
-    | ~cord_num~       | ~int64_t~                                                        | in     | Order of polynomials              |
-    | ~elec_num~       | ~int64_t~                                                        | in     | Number of electrons               |
-    | ~nucl_num~       | ~int64_t~                                                        | in     | Number of nucleii                 |
-    | ~walk_num~       | ~int64_t~                                                        | in     | Number of walkers                 |
-    | ~een_rescaled_e~ | ~double[walk_num][0:cord_num][elec_num][elec_num]~               | in     | Electron-electron rescaled factor |
-    | ~een_rescaled_n~ | ~double[walk_num][0:cord_num][nucl_num][elec_num]~               | in     | Electron-nucleus rescaled factor  |
-    | ~tmp_c~          | ~double[walk_num][0:cord_num-1][0:cord_num][nucl_num][elec_num]~ | out    | vector of non-zero coefficients   |
-
-
-    #+begin_src c :comments org :tangle (eval c) :noweb yes
+     #+begin_src c :comments org :tangle (eval c) :noweb yes
 #ifdef HAVE_OPENACC_OFFLOAD
-qmckl_exit_code qmckl_compute_tmp_c_acc_offload (
-	  const qmckl_context context,
-	  const int64_t cord_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t walk_num,
-	  const double* een_rescaled_e,
-	  const double* een_rescaled_n,
-	  double* const tmp_c ) {
+qmckl_exit_code
+qmckl_compute_tmp_c_acc_offload (const qmckl_context context,
+                                 const int64_t cord_num,
+                                 const int64_t elec_num,
+                                 const int64_t nucl_num,
+                                 const int64_t walk_num,
+                                 const double* een_rescaled_e,
+                                 const double* een_rescaled_n,
+                                 double* const tmp_c )
+{
 
   if (context == QMCKL_NULL_CONTEXT) {
     return QMCKL_INVALID_CONTEXT;
@@ -5689,110 +6053,82 @@ qmckl_exit_code qmckl_compute_tmp_c_acc_offload (
 
   // Compute array access strides:
   // For tmp_c...
-  int stride_k_c  = elec_num;
-  int stride_j_c  = stride_k_c * nucl_num;
-  int stride_i_c  = stride_j_c * (cord_num+1);
-  int stride_nw_c = stride_i_c * cord_num;
+  const int64_t stride_k_c  = elec_num;
+  const int64_t stride_j_c  = stride_k_c * nucl_num;
+  const int64_t stride_i_c  = stride_j_c * (cord_num+1);
+  const int64_t stride_nw_c = stride_i_c * cord_num;
   // For een_rescaled_e...
-  int stride_m_e  = elec_num;
-  int stride_i_e  = stride_m_e * elec_num;
-  int stride_nw_e = stride_i_e * (cord_num+1);
+  const int64_t stride_m_e  = elec_num;
+  const int64_t stride_i_e  = stride_m_e * elec_num;
+  const int64_t stride_nw_e = stride_i_e * (cord_num+1);
   // For een_rescaled_n...
-  int stride_k_n  = elec_num;
-  int stride_j_n  = stride_k_n * nucl_num;
-  int stride_nw_n = stride_j_n * (cord_num+1);
+  const int64_t stride_k_n  = elec_num;
+  const int64_t stride_j_n  = stride_k_n * nucl_num;
+  const int64_t stride_nw_n = stride_j_n * (cord_num+1);
 
-  #pragma acc parallel
-  #pragma acc loop independent gang worker vector collapse(5)
-  for (int nw=0; nw < walk_num; ++nw) {
-    for (int i=0; i<cord_num; ++i){
+  const int64_t size_tmp_c = elec_num*nucl_num*(cord_num+1)*cord_num*walk_num;
+  const int64_t size_e = walk_num*(cord_num+1)*elec_num*elec_num;
+  const int64_t size_n = walk_num*(cord_num+1)*nucl_num*elec_num;
 
-      // Replacement for single DGEMM
-      for (int j=0; j<cord_num+1; j++) {
-        for (int k=0; k<nucl_num; k++) {
-          for (int l=0; l<elec_num; l++) {
+  #pragma acc parallel copyout(tmp_c [0:size_tmp_c]) copyin(een_rescaled_e[0:size_e], een_rescaled_n[0:size_n])
+  {
+#pragma acc loop independent gang worker vector collapse(5)
+    for (int nw=0; nw < walk_num; ++nw) {
+      for (int i=0; i<cord_num; ++i){
 
-            // Single reduction
-			  tmp_c[l + k*stride_k_c + j*stride_j_c + i*stride_i_c + nw*stride_nw_c] = 0;
-            for (int m=0; m<elec_num; m++) {
-              tmp_c[l + k*stride_k_c + j*stride_j_c + i*stride_i_c + nw*stride_nw_c] =
-              tmp_c[l + k*stride_k_c + j*stride_j_c + i*stride_i_c + nw*stride_nw_c] +
-              een_rescaled_e[l + m*stride_m_e + i*stride_i_e + nw*stride_nw_e] *
-              een_rescaled_n[m + k*stride_k_n + j*stride_j_n + nw*stride_nw_n];
+        // Replacement for single DGEMM
+        for (int j=0; j<cord_num+1; j++) {
+          for (int k=0; k<nucl_num; k++) {
+            for (int l=0; l<elec_num; l++) {
+
+              // Single reduction
+              tmp_c[l + k*stride_k_c + j*stride_j_c + i*stride_i_c + nw*stride_nw_c] = 0.;
+              for (int m=0; m<elec_num; m++) {
+                tmp_c[l + k*stride_k_c + j*stride_j_c + i*stride_i_c + nw*stride_nw_c] =
+                tmp_c[l + k*stride_k_c + j*stride_j_c + i*stride_i_c + nw*stride_nw_c] +
+                een_rescaled_e[l + m*stride_m_e + i*stride_i_e + nw*stride_nw_e] *
+                een_rescaled_n[m + k*stride_k_n + j*stride_j_n + nw*stride_nw_n];
             }
-
           }
         }
       }
     }
   }
+  }
 
   return QMCKL_SUCCESS;
 }
 #endif
-    #+end_src
+     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_tmp_c_acc_offload_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
-
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
 #ifdef HAVE_OPENACC_OFFLOAD
-    qmckl_exit_code qmckl_compute_tmp_c_acc_offload (
-	  const qmckl_context context,
-	  const int64_t cord_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t walk_num,
-	  const double* een_rescaled_e,
-	  const double* een_rescaled_n,
-	  double* const tmp_c );
+qmckl_exit_code
+qmckl_compute_tmp_c_acc_offload (const qmckl_context context,
+                                 const int64_t cord_num,
+                                 const int64_t elec_num,
+                                 const int64_t nucl_num,
+                                 const int64_t walk_num,
+                                 const double* een_rescaled_e,
+                                 const double* een_rescaled_n,
+                                 double* const tmp_c );
 #endif
-    #+end_src
+     #+end_src
 
- TODO: FIX dtmp_c dimension in the table.
+**** OpenMP offload                                                :noexport:
 
-*** Compute tmp_c (cuBLAS offload)
-   :PROPERTIES:
-   :Name:     qmckl_compute_tmp_c_acc_offload
-   :CRetType: qmckl_exit_code
-   :FRetType: qmckl_exit_code
-   :END:
-
-    #+NAME: qmckl_factor_tmp_c_cublas_offload_args
-    | Variable         | Type                                                             | In/Out | Description                       |
-    |------------------+------------------------------------------------------------------+--------+-----------------------------------|
-    | ~context~        | ~qmckl_context~                                                  | in     | Global state                      |
-    | ~cord_num~       | ~int64_t~                                                        | in     | Order of polynomials              |
-    | ~elec_num~       | ~int64_t~                                                        | in     | Number of electrons               |
-    | ~nucl_num~       | ~int64_t~                                                        | in     | Number of nucleii                 |
-    | ~walk_num~       | ~int64_t~                                                        | in     | Number of walkers                 |
-    | ~een_rescaled_e~ | ~double[walk_num][0:cord_num][elec_num][elec_num]~               | in     | Electron-electron rescaled factor |
-    | ~een_rescaled_n~ | ~double[walk_num][0:cord_num][nucl_num][elec_num]~               | in     | Electron-nucleus rescaled factor  |
-    | ~tmp_c~          | ~double[walk_num][0:cord_num-1][0:cord_num][nucl_num][elec_num]~ | out    | vector of non-zero coefficients   |
-
-
-    #+begin_src c :comments org :tangle (eval c) :noweb yes
-#ifdef HAVE_CUBLAS_OFFLOAD
-qmckl_exit_code qmckl_compute_tmp_c_cublas_offload (
-	  const qmckl_context context,
-	  const int64_t cord_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t walk_num,
-	  const double* een_rescaled_e,
-	  const double* een_rescaled_n,
-	  double* const tmp_c ) {
-
-  qmckl_exit_code info;
-  int          i, j, a, l, kk, p, lmax, nw;
-  char         TransA, TransB;
-  double       alpha, beta;
-  int          M, N, K, LDA, LDB, LDC;
-
-  TransA = 'N';
-  TransB = 'N';
-  alpha  = 1.0;
-  beta   = 0.0;
+     #+begin_src c :comments org :tangle (eval c) :noweb yes
+#ifdef HAVE_OPENMP_OFFLOAD
+qmckl_exit_code
+qmckl_compute_tmp_c_omp_offload (const qmckl_context context,
+                                 const int64_t cord_num,
+                                 const int64_t elec_num,
+                                 const int64_t nucl_num,
+                                 const int64_t walk_num,
+                                 const double* een_rescaled_e,
+                                 const double* een_rescaled_n,
+                                 double* const tmp_c )
+{
 
   if (context == QMCKL_NULL_CONTEXT) {
     return QMCKL_INVALID_CONTEXT;
@@ -5810,55 +6146,167 @@ qmckl_exit_code qmckl_compute_tmp_c_cublas_offload (
     return QMCKL_INVALID_ARG_4;
   }
 
-  M = elec_num;
-  N = nucl_num*(cord_num + 1);
-  K = elec_num;
+  // Compute array access strides:
+  // For tmp_c...
+  const int64_t stride_k_c  = elec_num;
+  const int64_t stride_j_c  = stride_k_c * nucl_num;
+  const int64_t stride_i_c  = stride_j_c * (cord_num+1);
+  const int64_t stride_nw_c = stride_i_c * cord_num;
+  // For een_rescaled_e...
+  const int64_t stride_m_e  = elec_num;
+  const int64_t stride_i_e  = stride_m_e * elec_num;
+  const int64_t stride_nw_e = stride_i_e * (cord_num+1);
+  // For een_rescaled_n...
+  const int64_t stride_k_n  = elec_num;
+  const int64_t stride_j_n  = stride_k_n * nucl_num;
+  const int64_t stride_nw_n = stride_j_n * (cord_num+1);
 
-  LDA = sizeof(een_rescaled_e)/sizeof(double);
-  LDB = sizeof(een_rescaled_n)/sizeof(double);
-  LDC = sizeof(tmp_c)/sizeof(double);
+  const int64_t size_tmp_c = elec_num*nucl_num*(cord_num+1)*cord_num*walk_num;
+  const int64_t size_e = walk_num*(cord_num+1)*elec_num*elec_num;
+  const int64_t size_n = walk_num*(cord_num+1)*nucl_num*elec_num;
 
-  // TODO Replace with cuBLAS calls
-  for (int nw=0; nw < walk_num; ++nw) {
-    for (int i=0; i<cord_num; ++i){
-    info = qmckl_dgemm(context,TransA, TransB, M, N, K, alpha,     \
-                 //    &een_rescaled_e[0+0*elec_num+i*elec_num*elec_num+nw*elec_num*elec_num*(cord_num+1)],
-                       &een_rescaled_e[             i*elec_num*elec_num+nw*elec_num*elec_num*(cord_num+1)], \
-                       LDA,                                        \
-                 //    &een_rescaled_n[0+0*elec_num+0*elec_num*nucl_num+nw*elec_num*nucl_num*(cord_num+1)],
-                       &een_rescaled_n[                                 nw*elec_num*nucl_num*(cord_num+1)], \
-                       LDB,                                        \
-                       beta,                                       \
-                 //    &tmp_c[0+0*elec_num+0*elec_num*nucl_num+i*elec_num*nucl_num*(cord_num+1)+nw*elec_num*nucl_num*(cord_num+1)*cord_num],
-                       &tmp_c[                                 i*elec_num*nucl_num*(cord_num+1)+nw*elec_num*nucl_num*(cord_num+1)*cord_num],        \
-                       LDC);
 
+  // WARNING This implementation seems unomptimized
+  #pragma omp target map(from:tmp_c[0:size_tmp_c]) map(to:een_rescaled_e[0:size_e], een_rescaled_n[0:size_n])
+  {
+  #pragma omp teams distribute parallel for collapse(5)
+    for (int nw=0; nw < walk_num; ++nw) {
+      for (int i=0; i<cord_num; ++i){
+
+        // Replacement for single DGEMM
+        for (int j=0; j<cord_num+1; j++) {
+          for (int k=0; k<nucl_num; k++) {
+            for (int l=0; l<elec_num; l++) {
+
+              // Single reduction
+              tmp_c[l + k*stride_k_c + j*stride_j_c + i*stride_i_c + nw*stride_nw_c] = 0.;
+              for (int m=0; m<elec_num; m++) {
+                tmp_c[l + k*stride_k_c + j*stride_j_c + i*stride_i_c + nw*stride_nw_c] =
+                  tmp_c[l + k*stride_k_c + j*stride_j_c + i*stride_i_c + nw*stride_nw_c] +
+                  een_rescaled_e[l + m*stride_m_e + i*stride_i_e + nw*stride_nw_e] *
+                  een_rescaled_n[m + k*stride_k_n + j*stride_j_n + nw*stride_nw_n];
+              }
+            }
+          }
+        }
+      }
     }
   }
 
-  return info;
+  return QMCKL_SUCCESS;
 }
 #endif
-    #+end_src
+     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_tmp_c_cublas_offload_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
-
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
-#ifdef HAVE_CUBLAS_OFFLOAD
-    qmckl_exit_code qmckl_compute_tmp_c_cublas_offload (
-	  const qmckl_context context,
-	  const int64_t cord_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t walk_num,
-	  const double* een_rescaled_e,
-	  const double* een_rescaled_n,
-	  double* const tmp_c );
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
+#ifdef HAVE_OPENMP_OFFLOAD
+qmckl_exit_code
+qmckl_compute_tmp_c_omp_offload (const qmckl_context context,
+                                 const int64_t cord_num,
+                                 const int64_t elec_num,
+                                 const int64_t nucl_num,
+                                 const int64_t walk_num,
+                                 const double* een_rescaled_e,
+                                 const double* een_rescaled_n,
+                                 double* const tmp_c );
 #endif
-    #+end_src
+     #+end_src
 
- TODO: FIX dtmp_c dimension in the table.
+**** cuBLAS offload                                                :noexport:
+
+#+begin_src c :comments org :tangle (eval c) :noweb yes
+#ifdef HAVE_CUBLAS_OFFLOAD
+qmckl_exit_code
+qmckl_compute_tmp_c_cublas_offload (const qmckl_context context,
+                                    const int64_t cord_num,
+                                    const int64_t elec_num,
+                                    const int64_t nucl_num,
+                                    const int64_t walk_num,
+                                    const double* een_rescaled_e,
+                                    const double* een_rescaled_n,
+                                    double* const tmp_c )
+{
+  qmckl_exit_code info;
+
+  if (context == QMCKL_NULL_CONTEXT) {
+    return QMCKL_INVALID_CONTEXT;
+  }
+
+  if (cord_num <= 0) {
+    return QMCKL_INVALID_ARG_2;
+  }
+
+  if (elec_num <= 0) {
+    return QMCKL_INVALID_ARG_3;
+  }
+
+  if (nucl_num <= 0) {
+    return QMCKL_INVALID_ARG_4;
+  }
+
+  //cuBLAS initialization
+  cublasHandle_t handle;
+  if (cublasCreate(&handle) != CUBLAS_STATUS_SUCCESS)
+  {
+    fprintf(stdout, "CUBLAS initialization failed!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  const double alpha = 1.0;
+  const double beta  = 0.0;
+
+  const int64_t M = elec_num;
+  const int64_t N = nucl_num*(cord_num + 1);
+  const int64_t K = elec_num;
+
+  const int64_t LDA = elec_num;
+  const int64_t LDB = elec_num;
+  const int64_t LDC = elec_num;
+
+  const int64_t af = elec_num*elec_num;
+  const int64_t bf = elec_num*nucl_num*(cord_num+1);
+  const int64_t cf = bf;
+
+  #pragma omp target enter data map(to:een_rescaled_e[0:elec_num*elec_num*(cord_num+1)*walk_num],een_rescaled_n[0:M*N*walk_num],tmp_c[0:elec_num*nucl_num*(cord_num+1)*cord_num*walk_num])
+  #pragma omp target data use_device_ptr(een_rescaled_e,een_rescaled_n,tmp_c)
+  {
+  for (int nw=0; nw < walk_num; ++nw) {
+
+    int cublasError = cublasDgemmStridedBatched(handle, CUBLAS_OP_N, CUBLAS_OP_N, M, N, K, &alpha,
+                                    &(een_rescaled_e[nw*(cord_num+1)]),
+                                    LDA, af,
+                                    &(een_rescaled_n[bf*nw]),
+                                    LDB, 0,
+                                    &beta,
+                                    &(tmp_c[nw*cord_num]),
+                                    LDC, cf, cord_num);
+  }
+  }
+  #pragma omp target exit data map(from:tmp_c[0:elec_num*nucl_num*(cord_num+1)*cord_num*walk_num])
+
+  cublasDestroy(handle);
+  return info;
+  }
+#endif
+
+#+end_src
+
+
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
+#ifdef HAVE_CUBLAS_OFFLOAD
+qmckl_exit_code
+qmckl_compute_tmp_c_cublas_offload (
+      const qmckl_context context,
+      const int64_t cord_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t walk_num,
+      const double* een_rescaled_e,
+      const double* een_rescaled_n,
+      double* const tmp_c );
+#endif
+     #+end_src
+
 *** Compute dtmp_c
    :PROPERTIES:
    :Name:     qmckl_compute_dtmp_c
@@ -5877,6 +6325,40 @@ qmckl_exit_code qmckl_compute_tmp_c_cublas_offload (
     | ~een_rescaled_e_deriv_e~ | ~double[walk_num][0:cord_num][elec_num][4][elec_num]~            | in     | Electron-electron rescaled factor derivatives |
     | ~een_rescaled_n~         | ~double[walk_num][0:cord_num][nucl_num][elec_num]~               | in     | Electron-nucleus rescaled factor              |
     | ~dtmp_c~                 | ~double[walk_num][0:cord_num-1][0:cord_num][nucl_num][elec_num]~ | out    | vector of non-zero coefficients               |
+
+
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
+qmckl_exit_code
+qmckl_compute_dtmp_c (const qmckl_context context,
+                      const int64_t cord_num,
+                      const int64_t elec_num,
+                      const int64_t nucl_num,
+                      const int64_t walk_num,
+                      const double* een_rescaled_e_deriv_e,
+                      const double* een_rescaled_n,
+                      double* const dtmp_c );
+     #+end_src
+
+     #+begin_src c :comments org :tangle (eval c) :noweb yes
+qmckl_exit_code
+qmckl_compute_dtmp_c (const qmckl_context context,
+                      const int64_t cord_num,
+                      const int64_t elec_num,
+                      const int64_t nucl_num,
+                      const int64_t walk_num,
+                      const double* een_rescaled_e_deriv_e,
+                      const double* een_rescaled_n,
+                      double* const dtmp_c )
+{
+#ifdef HAVE_HPC
+  return qmckl_compute_dtmp_c_hpc (context, cord_num, elec_num, nucl_num, walk_num, een_rescaled_e_deriv_e,
+                                   een_rescaled_n, dtmp_c );
+#else
+  return qmckl_compute_dtmp_c_doc (context, cord_num, elec_num, nucl_num, walk_num, een_rescaled_e_deriv_e,
+                                   een_rescaled_n, dtmp_c );
+#endif
+}
+     #+end_src
 
     #+begin_src f90 :comments org :tangle (eval f) :noweb yes
 integer function qmckl_compute_dtmp_c_doc_f( &
@@ -5942,11 +6424,11 @@ integer function qmckl_compute_dtmp_c_doc_f( &
              dtmp_c(1,1,1,0,i,nw),LDC)
      end do
   end do
-  
+
 end function qmckl_compute_dtmp_c_doc_f
     #+end_src
 
-#+CALL: generate_c_interface(table=qmckl_factor_dtmp_c_args,rettyp=get_value("FRetType"),fname="qmckl_compute_dtmp_c_doc")
+    #+CALL: generate_c_interface(table=qmckl_factor_dtmp_c_args,rettyp=get_value("FRetType"),fname="qmckl_compute_dtmp_c_doc")
 
 #+RESULTS:
 #+begin_src f90 :tangle (eval f) :comments org :exports none
@@ -5973,21 +6455,35 @@ integer(c_int32_t) function qmckl_compute_dtmp_c_doc &
 end function qmckl_compute_dtmp_c_doc
 #+end_src
 
-    
-    #+begin_src c :comments org :tangle (eval c) :noweb yes
-qmckl_exit_code qmckl_compute_dtmp_c_hpc (const qmckl_context context,
-                                          const int64_t cord_num,
-                                          const int64_t elec_num,
-                                          const int64_t nucl_num,
-                                          const int64_t walk_num,
-                                          const double* een_rescaled_e_deriv_e,
-                                          const double* een_rescaled_n,
-                                          double* const dtmp_c )
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
+qmckl_exit_code qmckl_compute_dtmp_c_doc (
+      const qmckl_context context,
+      const int64_t cord_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t walk_num,
+      const double* een_rescaled_e_deriv_e,
+      const double* een_rescaled_n,
+      double* const dtmp_c );
+     #+end_src
+
+**** CPU                                                           :noexport:
+
+     #+begin_src c :comments org :tangle (eval c) :noweb yes
+qmckl_exit_code
+qmckl_compute_dtmp_c_hpc (const qmckl_context context,
+                          const int64_t cord_num,
+                          const int64_t elec_num,
+                          const int64_t nucl_num,
+                          const int64_t walk_num,
+                          const double* een_rescaled_e_deriv_e,
+                          const double* een_rescaled_n,
+                          double* const dtmp_c )
 {
 
   if (context == QMCKL_NULL_CONTEXT) {
      return QMCKL_INVALID_CONTEXT;
-  } 
+  }
 
   if (cord_num <= 0) {
      return QMCKL_INVALID_ARG_2;
@@ -5999,11 +6495,11 @@ qmckl_exit_code qmckl_compute_dtmp_c_hpc (const qmckl_context context,
 
   if (nucl_num <= 0) {
      return QMCKL_INVALID_ARG_4;
-  } 
+  }
 
   if (walk_num <= 0) {
      return QMCKL_INVALID_ARG_5;
-  } 
+  }
 
   qmckl_exit_code  info = QMCKL_SUCCESS;
 
@@ -6024,111 +6520,48 @@ qmckl_exit_code qmckl_compute_dtmp_c_hpc (const qmckl_context context,
   const int64_t bf = elec_num*nucl_num*(cord_num+1);
   const int64_t cf = elec_num*4*nucl_num*(cord_num+1);
 
+#ifdef HAVE_OPENMP
+#pragma omp parallel for collapse(2)
+#endif
   for (int64_t nw=0; nw < walk_num; ++nw) {
     for (int64_t i=0; i < cord_num; ++i) {
-      info = qmckl_dgemm(context, TransA, TransB, M, N, K, alpha,        \
-                &(een_rescaled_e_deriv_e[af*(i+nw*(cord_num+1))]), \
-                LDA,                                               \
-                &(een_rescaled_n[bf*nw]),   \
-                LDB,                                               \
-                beta,                                              \
-                &(dtmp_c[cf*(i+nw*cord_num)]), \
-                LDC);
+      info = qmckl_dgemm(context, TransA, TransB, M, N, K, alpha,
+                         &(een_rescaled_e_deriv_e[af*(i+nw*(cord_num+1))]), LDA,
+                         &(een_rescaled_n[bf*nw]), LDB, beta,
+                         &(dtmp_c[cf*(i+nw*cord_num)]), LDC);
     }
   }
 
   return info;
 }
-    #+end_src
+     #+end_src
 
-
-    #+begin_src c :comments org :tangle (eval c) :noweb yes
-qmckl_exit_code qmckl_compute_dtmp_c (const qmckl_context context,
-                                      const int64_t cord_num,
-                                      const int64_t elec_num,
-                                      const int64_t nucl_num,
-                                      const int64_t walk_num,
-                                      const double* een_rescaled_e_deriv_e,
-                                      const double* een_rescaled_n,
-                                      double* const dtmp_c )
-{
-#ifdef HAVE_HPC
-  return qmckl_compute_dtmp_c_hpc (context, cord_num, elec_num, nucl_num, walk_num, een_rescaled_e_deriv_e,
-                                   een_rescaled_n, dtmp_c );
-#else
-  return qmckl_compute_dtmp_c_doc (context, cord_num, elec_num, nucl_num, walk_num, een_rescaled_e_deriv_e,
-                                   een_rescaled_n, dtmp_c );
-#endif
-}
-    #+end_src
-
-
-    #+begin_src c :tangle (eval h_func) :comments org
-qmckl_exit_code qmckl_compute_dtmp_c (const qmckl_context context,
-                                      const int64_t cord_num,
-                                      const int64_t elec_num,
-                                      const int64_t nucl_num,
-                                      const int64_t walk_num,
-                                      const double* een_rescaled_e_deriv_e,
-                                      const double* een_rescaled_n,
-                                      double* const dtmp_c );
-    #+end_src
-
-    #+begin_src c :tangle (eval h_private_func) :comments org
-    qmckl_exit_code qmckl_compute_dtmp_c_doc (
-	  const qmckl_context context,
-	  const int64_t cord_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t walk_num,
-	  const double* een_rescaled_e_deriv_e,
-	  const double* een_rescaled_n,
-	  double* const dtmp_c );
-    #+end_src
-
-    #+begin_src c :tangle (eval h_private_func) :comments org
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
 qmckl_exit_code qmckl_compute_dtmp_c_hpc (
-	  const qmckl_context context,
-	  const int64_t cord_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t walk_num,
-	  const double* een_rescaled_e_deriv_e,
-	  const double* een_rescaled_n,
-	  double* const dtmp_c );
-    #+end_src
-    
-*** Compute dtmp_c (OpenACC offload)
-   :PROPERTIES:
-   :Name:     qmckl_compute_dtmp_c_acc_offload
-   :CRetType: qmckl_exit_code
-   :FRetType: qmckl_exit_code
-   :END:
+      const qmckl_context context,
+      const int64_t cord_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t walk_num,
+      const double* een_rescaled_e_deriv_e,
+      const double* een_rescaled_n,
+      double* const dtmp_c );
+     #+end_src
 
-    #+NAME: qmckl_factor_dtmp_c_acc_offload_args
-    | Variable                 | Type                                                             | In/Out | Description                                   |
-    |--------------------------+------------------------------------------------------------------+--------+-----------------------------------------------|
-    | ~context~                | ~qmckl_context~                                                  | in     | Global state                                  |
-    | ~cord_num~               | ~int64_t~                                                        | in     | Order of polynomials                          |
-    | ~elec_num~               | ~int64_t~                                                        | in     | Number of electrons                           |
-    | ~nucl_num~               | ~int64_t~                                                        | in     | Number of nucleii                             |
-    | ~walk_num~               | ~int64_t~                                                        | in     | Number of walkers                             |
-    | ~een_rescaled_e_deriv_e~ | ~double[walk_num][0:cord_num][elec_num][4][elec_num]~            | in     | Electron-electron rescaled factor derivatives |
-    | ~een_rescaled_n~         | ~double[walk_num][0:cord_num][nucl_num][elec_num]~               | in     | Electron-nucleus rescaled factor              |
-    | ~dtmp_c~                 | ~double[walk_num][0:cord_num-1][0:cord_num][nucl_num][elec_num]~ | out    | vector of non-zero coefficients               |
+**** OpenACC offload                                               :noexport:
 
-
-    #+begin_src c :comments org :tangle (eval c) :noweb yes
+     #+begin_src c :comments org :tangle (eval c) :noweb yes
 #ifdef HAVE_OPENACC_OFFLOAD
-qmckl_exit_code qmckl_compute_dtmp_c_acc_offload (
-	  const qmckl_context context,
-	  const int64_t cord_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t walk_num,
-	  const double* een_rescaled_e_deriv_e,
-	  const double* een_rescaled_n,
-	  double* const dtmp_c ) {
+qmckl_exit_code
+qmckl_compute_dtmp_c_acc_offload (
+      const qmckl_context context,
+      const int64_t cord_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t walk_num,
+      const double* een_rescaled_e_deriv_e,
+      const double* een_rescaled_n,
+      double* const dtmp_c ) {
 
   if (context == QMCKL_NULL_CONTEXT) {
      return QMCKL_INVALID_CONTEXT;
@@ -6148,24 +6581,28 @@ qmckl_exit_code qmckl_compute_dtmp_c_acc_offload (
 
   // Compute strides...
   // For dtmp_c
-  int stride_l_d  = elec_num;
-  int stride_k_d  = stride_l_d * 4;
-  int stride_j_d  = stride_k_d * nucl_num;
-  int stride_i_d  = stride_j_d * (cord_num+1);
-  int stride_nw_d = stride_i_d * cord_num;
+  const int64_t stride_l_d  = elec_num;
+  const int64_t stride_k_d  = stride_l_d * 4;
+  const int64_t stride_j_d  = stride_k_d * nucl_num;
+  const int64_t stride_i_d  = stride_j_d * (cord_num+1);
+  const int64_t stride_nw_d = stride_i_d * cord_num;
   // For een_rescaled_e_deriv_e
-  int stride_l_e  = elec_num;
-  int stride_n_e  = stride_l_e * 4;
-  int stride_i_e  = stride_n_e * elec_num;
-  int stride_nw_e = stride_i_e * cord_num;
+  const int64_t stride_l_e  = elec_num;
+  const int64_t stride_n_e  = stride_l_e * 4;
+  const int64_t stride_i_e  = stride_n_e * elec_num;
+  const int64_t stride_nw_e = stride_i_e * cord_num;
   // For een_rescaled_n
-  int stride_k_n  = elec_num;
-  int stride_j_n  = stride_k_n * nucl_num;
-  int stride_nw_n = stride_j_n * (cord_num+1);
+  const int64_t stride_k_n  = elec_num;
+  const int64_t stride_j_n  = stride_k_n * nucl_num;
+  const int64_t stride_nw_n = stride_j_n * (cord_num+1);
 
+  const int64_t size_dtmp_c = walk_num*cord_num*(cord_num+1)*nucl_num*4*elec_num;
+  const int64_t size_n = walk_num*(cord_num+1)*nucl_num*elec_num;
+  const int64_t size_e = walk_num*(cord_num+1)*elec_num*4*elec_num;
 
-  #pragma acc parallel
-  #pragma loop independent gang worker vector collapse(6)
+  #pragma acc parallel copyout(dtmp_c [0:size_dtmp_c]) copyin(een_rescaled_e_deriv_e[0:size_e], een_rescaled_n[0:size_n])
+  {
+  #pragma acc loop independent gang worker vector collapse(6)
   for (int nw=0; nw < walk_num; nw++) {
     for (int i=0; i < cord_num; i++) {
 
@@ -6176,7 +6613,7 @@ qmckl_exit_code qmckl_compute_dtmp_c_acc_offload (
             for(int m=0; m<elec_num; m++) {
 
               // Single reduction
-				dtmp_c[m + l * stride_l_d + k * stride_k_d + j * stride_j_d + i * stride_i_d + nw * stride_nw_d] = 0;
+              dtmp_c[m + l * stride_l_d + k * stride_k_d + j * stride_j_d + i * stride_i_d + nw * stride_nw_d] = 0.;
               for(int n=0; n<elec_num; n++){
                 dtmp_c[m + l * stride_l_d + k * stride_k_d + j * stride_j_d + i * stride_i_d + nw * stride_nw_d] =
                 dtmp_c[m + l * stride_l_d + k * stride_k_d + j * stride_j_d + i * stride_i_d + nw * stride_nw_d] +
@@ -6189,70 +6626,40 @@ qmckl_exit_code qmckl_compute_dtmp_c_acc_offload (
       }
     }
   }
+  }
 
   return QMCKL_SUCCESS;
 }
 #endif
-    #+end_src
+     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_dtmp_c_acc_offload_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
-
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
-
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
 #ifdef HAVE_OPENACC_OFFLOAD
     qmckl_exit_code qmckl_compute_dtmp_c_acc_offload (
-	  const qmckl_context context,
-	  const int64_t cord_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t walk_num,
-	  const double* een_rescaled_e_deriv_e,
-	  const double* een_rescaled_n,
-	  double* const dtmp_c );
+      const qmckl_context context,
+      const int64_t cord_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t walk_num,
+      const double* een_rescaled_e_deriv_e,
+      const double* een_rescaled_n,
+      double* const dtmp_c );
 #endif
-    #+end_src
-*** Compute dtmp_c (cuBLAS offload)
-   :PROPERTIES:
-   :Name:     qmckl_compute_dtmp_c_cublas_offload
-   :CRetType: qmckl_exit_code
-   :FRetType: qmckl_exit_code
-   :END:
+     #+end_src
 
-    #+NAME: qmckl_factor_dtmp_c_cublas_offload_args
-    | Variable                 | Type                                                             | In/Out | Description                                   |
-    |--------------------------+------------------------------------------------------------------+--------+-----------------------------------------------|
-    | ~context~                | ~qmckl_context~                                                  | in     | Global state                                  |
-    | ~cord_num~               | ~int64_t~                                                        | in     | Order of polynomials                          |
-    | ~elec_num~               | ~int64_t~                                                        | in     | Number of electrons                           |
-    | ~nucl_num~               | ~int64_t~                                                        | in     | Number of nucleii                             |
-    | ~walk_num~               | ~int64_t~                                                        | in     | Number of walkers                             |
-    | ~een_rescaled_e_deriv_e~ | ~double[walk_num][0:cord_num][elec_num][4][elec_num]~            | in     | Electron-electron rescaled factor derivatives |
-    | ~een_rescaled_n~         | ~double[walk_num][0:cord_num][nucl_num][elec_num]~               | in     | Electron-nucleus rescaled factor              |
-    | ~dtmp_c~                 | ~double[walk_num][0:cord_num-1][0:cord_num][nucl_num][elec_num]~ | out    | vector of non-zero coefficients               |
+**** OpenMP offload                                                :noexport:
 
-
-    #+begin_src c :comments org :tangle (eval c) :noweb yes
-#ifdef HAVE_CUBLAS_OFFLOAD
-qmckl_exit_code qmckl_compute_dtmp_c_cublas_offload (
-	  const qmckl_context context,
-	  const int64_t cord_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t walk_num,
-	  const double* een_rescaled_e_deriv_e,
-	  const double* een_rescaled_n,
-	  double* const dtmp_c ) {
-
-  qmckl_exit_code  info;
-  char             TransA, TransB;
-  double           alpha, beta;
-  int              M, N, K, LDA, LDB, LDC;
-
-  TransA = 'N';
-  TransB = 'N';
-  alpha = 1.0;
-  beta  = 0.0;
+     #+begin_src c :comments org :tangle (eval c) :noweb yes
+#ifdef HAVE_OPENMP_OFFLOAD
+qmckl_exit_code qmckl_compute_dtmp_c_omp_offload (
+      const qmckl_context context,
+      const int64_t cord_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t walk_num,
+      const double* een_rescaled_e_deriv_e,
+      const double* een_rescaled_n,
+      double* const dtmp_c ) {
 
   if (context == QMCKL_NULL_CONTEXT) {
      return QMCKL_INVALID_CONTEXT;
@@ -6270,53 +6677,174 @@ qmckl_exit_code qmckl_compute_dtmp_c_cublas_offload (
      return QMCKL_INVALID_ARG_4;
   }
 
-  M = 4*elec_num;
-  N = nucl_num*(cord_num + 1);
-  K = elec_num;
+  // Compute strides...
+  // For dtmp_c
+  const int64_t stride_l_d  = elec_num;
+  const int64_t stride_k_d  = stride_l_d * 4;
+  const int64_t stride_j_d  = stride_k_d * nucl_num;
+  const int64_t stride_i_d  = stride_j_d * (cord_num+1);
+  const int64_t stride_nw_d = stride_i_d * cord_num;
+  // For een_rescaled_e_deriv_e
+  const int64_t stride_l_e  = elec_num;
+  const int64_t stride_n_e  = stride_l_e * 4;
+  const int64_t stride_i_e  = stride_n_e * elec_num;
+  const int64_t stride_nw_e = stride_i_e * cord_num;
+  // For een_rescaled_n
+  const int64_t stride_k_n  = elec_num;
+  const int64_t stride_j_n  = stride_k_n * nucl_num;
+  const int64_t stride_nw_n = stride_j_n * (cord_num+1);
 
-  LDA = 4*sizeof(een_rescaled_e_deriv_e)/sizeof(double);
-  LDB = sizeof(een_rescaled_n)/sizeof(double);
-  LDC = 4*sizeof(dtmp_c)/sizeof(double);
 
-  // TODO Replace with cuBLAS calls
-  for (int nw=0; nw < walk_num; ++nw) {
-    for (int i=0; nw < cord_num; ++i) {
-      info = qmckl_dgemm(context,TransA, TransB, M, N, K, alpha,        \
-              //&een_rescaled_e_deriv_e[0+0*elec_num+0*elec_num*4+i*elec_num*4*elec_num+nw*elec_num*4*elec_num*(cord_num+1)],
-                &een_rescaled_e_deriv_e[i*elec_num*4*elec_num+nw*elec_num*4*elec_num*(cord_num+1)],                \
-                LDA,                                               \
-              //&een_rescaled_n[0+0*elec_num+0*elec_num*nucl_num+nw*elec_num*nucl_num*(cord_num+1)],
-                &een_rescaled_n[nw*elec_num*nucl_num*(cord_num+1)],   \
-                LDB,                                               \
-                beta,                                              \
-              //&dtmp_c[0+0*elec_num+0*elec_num*4+0*elec_num*4*nucl_num+i*elec_num*4*nucl_num*(cord_num+1)+nw*elec_num*4*nucl_num*(cord_num+1)*cord_num],
-                &dtmp_c[i*elec_num*4*nucl_num*(cord_num+1)+nw*elec_num*4*nucl_num*(cord_num+1)*cord_num], \
-                LDC);
+  const int64_t size_dtmp_c = walk_num*cord_num*(cord_num+1)*nucl_num*4*elec_num;
+  const int64_t size_n = walk_num*(cord_num+1)*nucl_num*elec_num;
+  const int64_t size_e = walk_num*(cord_num+1)*elec_num*4*elec_num;
+
+  // WARNING This implementation seems unomptimized
+  #pragma omp target map(from:dtmp_c[0:size_dtmp_c]) map(to:een_rescaled_e_deriv_e[0:size_e], een_rescaled_n[0:size_n])
+  {
+
+  #pragma omp teams distribute parallel for collapse(6)
+  for (int nw=0; nw < walk_num; nw++) {
+    for (int i=0; i < cord_num; i++) {
+
+      // Single DGEMM
+      for(int j=0; j<cord_num+1; j++) {
+        for(int k=0; k<nucl_num; k++) {
+          for(int l=0; l<4; l++) {
+            for(int m=0; m<elec_num; m++) {
+
+              // Single reduction
+              dtmp_c[m + l * stride_l_d + k * stride_k_d + j * stride_j_d + i * stride_i_d + nw * stride_nw_d] = 0;
+              for(int n=0; n<elec_num; n++){
+                dtmp_c[m + l * stride_l_d + k * stride_k_d + j * stride_j_d + i * stride_i_d + nw * stride_nw_d] =
+                dtmp_c[m + l * stride_l_d + k * stride_k_d + j * stride_j_d + i * stride_i_d + nw * stride_nw_d] +
+                een_rescaled_e_deriv_e[m + l * stride_l_e +  n * stride_n_e + i * stride_i_e + nw * stride_nw_e] *
+                een_rescaled_n[n + k * stride_k_n + j * stride_j_n + nw * stride_nw_n];
+              }
+            }
+          }
+        }
+      }
     }
   }
+  }
 
+  return QMCKL_SUCCESS;
+}
+#endif
+     #+end_src
+
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
+#ifdef HAVE_OPENMP_OFFLOAD
+    qmckl_exit_code qmckl_compute_dtmp_c_omp_offload (
+      const qmckl_context context,
+      const int64_t cord_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t walk_num,
+      const double* een_rescaled_e_deriv_e,
+      const double* een_rescaled_n,
+      double* const dtmp_c );
+#endif
+     #+end_src
+
+**** cuBLAS offload                                                :noexport:
+
+     #+begin_src c :comments org :tangle (eval c) :noweb yes
+#ifdef HAVE_CUBLAS_OFFLOAD
+qmckl_exit_code
+qmckl_compute_dtmp_c_cublas_offload (
+      const qmckl_context context,
+      const int64_t cord_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t walk_num,
+      const double* een_rescaled_e_deriv_e,
+      const double* een_rescaled_n,
+      double* const dtmp_c ) {
+
+  if (context == QMCKL_NULL_CONTEXT) {
+    return QMCKL_INVALID_CONTEXT;
+  }
+
+  if (cord_num <= 0) {
+    return QMCKL_INVALID_ARG_2;
+  }
+
+  if (elec_num <= 0) {
+    return QMCKL_INVALID_ARG_3;
+  }
+
+  if (nucl_num <= 0) {
+    return QMCKL_INVALID_ARG_4;
+  }
+
+  if (walk_num <= 0) {
+    return QMCKL_INVALID_ARG_5;
+  }
+
+  qmckl_exit_code  info = QMCKL_SUCCESS;
+
+  //cuBLAS initialization
+  cublasHandle_t handle;
+  if (cublasCreate(&handle) != CUBLAS_STATUS_SUCCESS)
+  {
+    fprintf(stdout, "CUBLAS initialization failed!\n");
+    exit(EXIT_FAILURE);
+  }
+
+  const double alpha = 1.0;
+  const double beta  = 0.0;
+
+  const int64_t M = 4*elec_num;
+  const int64_t N = nucl_num*(cord_num + 1);
+  const int64_t K = elec_num;
+
+  const int64_t LDA = 4*elec_num;
+  const int64_t LDB = elec_num;
+  const int64_t LDC = 4*elec_num;
+
+  const int64_t af = elec_num*elec_num*4;
+  const int64_t bf = elec_num*nucl_num*(cord_num+1);
+  const int64_t cf = elec_num*4*nucl_num*(cord_num+1);
+
+  #pragma omp target enter data map(to:een_rescaled_e_deriv_e[0:elec_num*4*elec_num*(cord_num+1)*walk_num], een_rescaled_n[0:elec_num*nucl_num*(cord_num+1)*walk_num], dtmp_c[0:elec_num*4*nucl_num*(cord_num+1)*cord_num*walk_num])
+  #pragma omp target data use_device_ptr(een_rescaled_e_deriv_e, een_rescaled_n, dtmp_c)
+  {
+  for (int64_t nw=0; nw < walk_num; ++nw) {
+    int cublasError = cublasDgemmStridedBatched(handle, CUBLAS_OP_N, CUBLAS_OP_N, M, N, K, &alpha,
+                                      &(een_rescaled_e_deriv_e[(nw*(cord_num+1))]),
+                                      LDA, af,
+                                      &(een_rescaled_n[bf*nw]), LDB, 0,
+                                      &beta,
+                                      &(dtmp_c[(nw*cord_num)]),
+                                      LDC, cf, cord_num);
+
+  }
+  }
+
+  #pragma omp target exit data map(from:dtmp_c[0:cf*cord_num*walk_num])
+
+  cublasDestroy(handle);
   return info;
 }
 #endif
-    #+end_src
+     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_dtmp_c_cublas_offload_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
-
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
-
+     #+RESULTS:
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
 #ifdef HAVE_CUBLAS_OFFLOAD
     qmckl_exit_code qmckl_compute_dtmp_c_cublas_offload (
-	  const qmckl_context context,
-	  const int64_t cord_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t walk_num,
-	  const double* een_rescaled_e_deriv_e,
-	  const double* een_rescaled_n,
-	  double* const dtmp_c );
+      const qmckl_context context,
+      const int64_t cord_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t walk_num,
+      const double* een_rescaled_e_deriv_e,
+      const double* een_rescaled_n,
+      double* const dtmp_c );
 #endif
-    #+end_src
+     #+end_src
 
 *** Test
 
@@ -6397,9 +6925,12 @@ rc = qmckl_get_jastrow_tmp_c(context, &(tmp_c[0][0][0][0][0]));
 double dtmp_c[walk_num][cord_num][cord_num+1][nucl_num][4][elec_num];
 rc = qmckl_get_jastrow_dtmp_c(context, &(dtmp_c[0][0][0][0][0][0]));
 
+printf("%e\n%e\n", tmp_c[0][0][1][0][0], 2.7083473948352403);
 assert(fabs(tmp_c[0][0][1][0][0] - 2.7083473948352403) < 1e-12);
 
+printf("%e\n%e\n", tmp_c[0][1][0][0][0],0.237440520852232);
 assert(fabs(dtmp_c[0][1][0][0][0][0] - 0.237440520852232) < 1e-12);
+return QMCKL_SUCCESS;
      #+end_src
 
 ** Electron-electron-nucleus Jastrow \(f_{een}\)
@@ -6627,22 +7158,21 @@ integer function qmckl_compute_factor_een_naive_f( &
 end function qmckl_compute_factor_een_naive_f
     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_een_naive_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+#   #+CALL: generate_c_header(table=qmckl_factor_een_naive_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
     qmckl_exit_code qmckl_compute_factor_een_naive (
-	  const qmckl_context context,
-	  const int64_t walk_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t cord_num,
-	  const int64_t dim_cord_vect,
-	  const double* cord_vect_full,
-	  const int64_t* lkpm_combined_index,
-	  const double* een_rescaled_e,
-	  const double* een_rescaled_n,
-	  double* const factor_een );
+      const qmckl_context context,
+      const int64_t walk_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t cord_num,
+      const int64_t dim_cord_vect,
+      const double* cord_vect_full,
+      const int64_t* lkpm_combined_index,
+      const double* een_rescaled_e,
+      const double* een_rescaled_n,
+      double* const factor_een );
     #+end_src
 
     #+CALL: generate_c_interface(table=qmckl_factor_een_naive_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
@@ -6650,18 +7180,18 @@ end function qmckl_compute_factor_een_naive_f
     #+RESULTS:
     #+begin_src f90 :tangle (eval f) :comments org :exports none
     integer(c_int32_t) function qmckl_compute_factor_een_naive &
-	(context, &
-		 walk_num, &
-		 elec_num, &
-		 nucl_num, &
-		 cord_num, &
-		 dim_cord_vect, &
-		 cord_vect_full, &
-		 lkpm_combined_index, &
-		 een_rescaled_e, &
-		 een_rescaled_n, &
-		 factor_een) &
-	bind(C) result(info)
+    (context, &
+         walk_num, &
+         elec_num, &
+         nucl_num, &
+         cord_num, &
+         dim_cord_vect, &
+         cord_vect_full, &
+         lkpm_combined_index, &
+         een_rescaled_e, &
+         een_rescaled_n, &
+         factor_een) &
+    bind(C) result(info)
 
       use, intrinsic :: iso_c_binding
       implicit none
@@ -6680,17 +7210,17 @@ end function qmckl_compute_factor_een_naive_f
 
       integer(c_int32_t), external :: qmckl_compute_factor_een_naive_f
       info = qmckl_compute_factor_een_naive_f &
-	     (context, &
-		 walk_num, &
-		 elec_num, &
-		 nucl_num, &
-		 cord_num, &
-		 dim_cord_vect, &
-		 cord_vect_full, &
-		 lkpm_combined_index, &
-		 een_rescaled_e, &
-		 een_rescaled_n, &
-		 factor_een)
+         (context, &
+         walk_num, &
+         elec_num, &
+         nucl_num, &
+         cord_num, &
+         dim_cord_vect, &
+         cord_vect_full, &
+         lkpm_combined_index, &
+         een_rescaled_e, &
+         een_rescaled_n, &
+         factor_een)
 
     end function qmckl_compute_factor_een_naive
     #+end_src
@@ -6788,22 +7318,21 @@ integer function qmckl_compute_factor_een_f( &
 end function qmckl_compute_factor_een_f
     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_een_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+#   #+CALL: generate_c_header(table=qmckl_factor_een_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
     qmckl_exit_code qmckl_compute_factor_een (
-	  const qmckl_context context,
-	  const int64_t walk_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t cord_num,
-	  const int64_t dim_cord_vect,
-	  const double* cord_vect_full,
-	  const int64_t* lkpm_combined_index,
-	  const double* een_rescaled_e,
-	  const double* een_rescaled_n,
-	  double* const factor_een );
+      const qmckl_context context,
+      const int64_t walk_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t cord_num,
+      const int64_t dim_cord_vect,
+      const double* cord_vect_full,
+      const int64_t* lkpm_combined_index,
+      const double* een_rescaled_e,
+      const double* een_rescaled_n,
+      double* const factor_een );
     #+end_src
 
     #+CALL: generate_c_interface(table=qmckl_factor_een_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
@@ -6811,18 +7340,18 @@ end function qmckl_compute_factor_een_f
     #+RESULTS:
     #+begin_src f90 :tangle (eval f) :comments org :exports none
     integer(c_int32_t) function qmckl_compute_factor_een &
-	(context, &
-		 walk_num, &
-		 elec_num, &
-		 nucl_num, &
-		 cord_num, &
-		 dim_cord_vect, &
-		 cord_vect_full, &
-		 lkpm_combined_index, &
-		 een_rescaled_e, &
-		 een_rescaled_n, &
-		 factor_een) &
-	bind(C) result(info)
+    (context, &
+         walk_num, &
+         elec_num, &
+         nucl_num, &
+         cord_num, &
+         dim_cord_vect, &
+         cord_vect_full, &
+         lkpm_combined_index, &
+         een_rescaled_e, &
+         een_rescaled_n, &
+         factor_een) &
+    bind(C) result(info)
 
       use, intrinsic :: iso_c_binding
       implicit none
@@ -6841,17 +7370,17 @@ end function qmckl_compute_factor_een_f
 
       integer(c_int32_t), external :: qmckl_compute_factor_een_f
       info = qmckl_compute_factor_een_f &
-	     (context, &
-		 walk_num, &
-		 elec_num, &
-		 nucl_num, &
-		 cord_num, &
-		 dim_cord_vect, &
-		 cord_vect_full, &
-		 lkpm_combined_index, &
-		 een_rescaled_e, &
-		 een_rescaled_n, &
-		 factor_een)
+         (context, &
+         walk_num, &
+         elec_num, &
+         nucl_num, &
+         cord_num, &
+         dim_cord_vect, &
+         cord_vect_full, &
+         lkpm_combined_index, &
+         een_rescaled_e, &
+         een_rescaled_n, &
+         factor_een)
 
     end function qmckl_compute_factor_een
     #+end_src
@@ -6900,6 +7429,7 @@ double factor_een[walk_num];
 rc = qmckl_get_jastrow_factor_een(context, &(factor_een[0]),walk_num);
 
 assert(fabs(factor_een[0] + 0.37407972141304213) < 1e-12);
+return QMCKL_SUCCESS;
      #+end_src
 
 ** Electron-electron-nucleus Jastrow \(f_{een}\) derivative
@@ -7162,24 +7692,23 @@ integer function qmckl_compute_factor_een_deriv_e_naive_f( &
 end function qmckl_compute_factor_een_deriv_e_naive_f
     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_een_deriv_e_naive_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+#   #+CALL: generate_c_header(table=qmckl_factor_een_deriv_e_naive_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
     qmckl_exit_code qmckl_compute_factor_een_deriv_e_naive (
-	  const qmckl_context context,
-	  const int64_t walk_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t cord_num,
-	  const int64_t dim_cord_vect,
-	  const double* cord_vect_full,
-	  const int64_t* lkpm_combined_index,
-	  const double* een_rescaled_e,
-	  const double* een_rescaled_n,
-	  const double* een_rescaled_e_deriv_e,
-	  const double* een_rescaled_n_deriv_e,
-	  double* const factor_een_deriv_e );
+      const qmckl_context context,
+      const int64_t walk_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t cord_num,
+      const int64_t dim_cord_vect,
+      const double* cord_vect_full,
+      const int64_t* lkpm_combined_index,
+      const double* een_rescaled_e,
+      const double* een_rescaled_n,
+      const double* een_rescaled_e_deriv_e,
+      const double* een_rescaled_n_deriv_e,
+      double* const factor_een_deriv_e );
     #+end_src
 
 
@@ -7188,20 +7717,20 @@ end function qmckl_compute_factor_een_deriv_e_naive_f
     #+RESULTS:
     #+begin_src f90 :tangle (eval f) :comments org :exports none
     integer(c_int32_t) function qmckl_compute_factor_een_deriv_e_naive &
-	(context, &
-		 walk_num, &
-		 elec_num, &
-		 nucl_num, &
-		 cord_num, &
-		 dim_cord_vect, &
-		 cord_vect_full, &
-		 lkpm_combined_index, &
-		 een_rescaled_e, &
-		 een_rescaled_n, &
-		 een_rescaled_e_deriv_e, &
-		 een_rescaled_n_deriv_e, &
-		 factor_een_deriv_e) &
-	bind(C) result(info)
+    (context, &
+         walk_num, &
+         elec_num, &
+         nucl_num, &
+         cord_num, &
+         dim_cord_vect, &
+         cord_vect_full, &
+         lkpm_combined_index, &
+         een_rescaled_e, &
+         een_rescaled_n, &
+         een_rescaled_e_deriv_e, &
+         een_rescaled_n_deriv_e, &
+         factor_een_deriv_e) &
+    bind(C) result(info)
 
       use, intrinsic :: iso_c_binding
       implicit none
@@ -7222,19 +7751,19 @@ end function qmckl_compute_factor_een_deriv_e_naive_f
 
       integer(c_int32_t), external :: qmckl_compute_factor_een_deriv_e_naive_f
       info = qmckl_compute_factor_een_deriv_e_naive_f &
-	     (context, &
-		 walk_num, &
-		 elec_num, &
-		 nucl_num, &
-		 cord_num, &
-		 dim_cord_vect, &
-		 cord_vect_full, &
-		 lkpm_combined_index, &
-		 een_rescaled_e, &
-		 een_rescaled_n, &
-		 een_rescaled_e_deriv_e, &
-		 een_rescaled_n_deriv_e, &
-		 factor_een_deriv_e)
+         (context, &
+         walk_num, &
+         elec_num, &
+         nucl_num, &
+         cord_num, &
+         dim_cord_vect, &
+         cord_vect_full, &
+         lkpm_combined_index, &
+         een_rescaled_e, &
+         een_rescaled_n, &
+         een_rescaled_e_deriv_e, &
+         een_rescaled_n_deriv_e, &
+         factor_een_deriv_e)
 
     end function qmckl_compute_factor_een_deriv_e_naive
     #+end_src
@@ -7354,24 +7883,23 @@ integer function qmckl_compute_factor_een_deriv_e_f( &
 end function qmckl_compute_factor_een_deriv_e_f
     #+end_src
 
-    #+CALL: generate_c_header(table=qmckl_factor_een_deriv_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
+#   #+CALL: generate_c_header(table=qmckl_factor_een_deriv_e_args,rettyp=get_value("CRetType"),fname=get_value("Name"))
 
-    #+RESULTS:
-    #+begin_src c :tangle (eval h_func) :comments org
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
     qmckl_exit_code qmckl_compute_factor_een_deriv_e (
-	  const qmckl_context context,
-	  const int64_t walk_num,
-	  const int64_t elec_num,
-	  const int64_t nucl_num,
-	  const int64_t cord_num,
-	  const int64_t dim_cord_vect,
-	  const double* cord_vect_full,
-	  const int64_t* lkpm_combined_index,
-	  const double* tmp_c,
-	  const double* dtmp_c,
-	  const double* een_rescaled_n,
-	  const double* een_rescaled_n_deriv_e,
-	  double* const factor_een_deriv_e );
+      const qmckl_context context,
+      const int64_t walk_num,
+      const int64_t elec_num,
+      const int64_t nucl_num,
+      const int64_t cord_num,
+      const int64_t dim_cord_vect,
+      const double* cord_vect_full,
+      const int64_t* lkpm_combined_index,
+      const double* tmp_c,
+      const double* dtmp_c,
+      const double* een_rescaled_n,
+      const double* een_rescaled_n_deriv_e,
+      double* const factor_een_deriv_e );
     #+end_src
 
 
@@ -7380,20 +7908,20 @@ end function qmckl_compute_factor_een_deriv_e_f
     #+RESULTS:
     #+begin_src f90 :tangle (eval f) :comments org :exports none
     integer(c_int32_t) function qmckl_compute_factor_een_deriv_e &
-	(context, &
-		 walk_num, &
-		 elec_num, &
-		 nucl_num, &
-		 cord_num, &
-		 dim_cord_vect, &
-		 cord_vect_full, &
-		 lkpm_combined_index, &
-		 tmp_c, &
-		 dtmp_c, &
-		 een_rescaled_n, &
-		 een_rescaled_n_deriv_e, &
-		 factor_een_deriv_e) &
-	bind(C) result(info)
+    (context, &
+         walk_num, &
+         elec_num, &
+         nucl_num, &
+         cord_num, &
+         dim_cord_vect, &
+         cord_vect_full, &
+         lkpm_combined_index, &
+         tmp_c, &
+         dtmp_c, &
+         een_rescaled_n, &
+         een_rescaled_n_deriv_e, &
+         factor_een_deriv_e) &
+    bind(C) result(info)
 
       use, intrinsic :: iso_c_binding
       implicit none
@@ -7414,19 +7942,19 @@ end function qmckl_compute_factor_een_deriv_e_f
 
       integer(c_int32_t), external :: qmckl_compute_factor_een_deriv_e_f
       info = qmckl_compute_factor_een_deriv_e_f &
-	     (context, &
-		 walk_num, &
-		 elec_num, &
-		 nucl_num, &
-		 cord_num, &
-		 dim_cord_vect, &
-		 cord_vect_full, &
-		 lkpm_combined_index, &
-		 tmp_c, &
-		 dtmp_c, &
-		 een_rescaled_n, &
-		 een_rescaled_n_deriv_e, &
-		 factor_een_deriv_e)
+         (context, &
+         walk_num, &
+         elec_num, &
+         nucl_num, &
+         cord_num, &
+         dim_cord_vect, &
+         cord_vect_full, &
+         lkpm_combined_index, &
+         tmp_c, &
+         dtmp_c, &
+         een_rescaled_n, &
+         een_rescaled_n_deriv_e, &
+         factor_een_deriv_e)
 
     end function qmckl_compute_factor_een_deriv_e
     #+end_src

--- a/org/qmckl_mo.org
+++ b/org/qmckl_mo.org
@@ -92,10 +92,12 @@ int main() {
 
   Computed data:
 
-  |---------------+--------------------------+-------------------------------------------------------------------------------------|
-  | ~mo_vgl~      | ~[point_num][5][mo_num]~ | Value, gradients, Laplacian of the MOs at point positions                           |
-  | ~mo_vgl_date~ | ~uint64_t~               | Late modification date of Value, gradients, Laplacian of the MOs at point positions |
-  |---------------+--------------------------+-------------------------------------------------------------------------------------|
+  |-----------------+--------------------------+-------------------------------------------------------------------------------------|
+  | ~mo_value~      | ~[point_num][mo_num]~    | Value of the MOs at point positions                                                 |
+  | ~mo_value_date~ | ~uint64_t~               | Late modification date of the value of the MOs at point positions                   |
+  | ~mo_vgl~        | ~[point_num][5][mo_num]~ | Value, gradients, Laplacian of the MOs at point positions                           |
+  | ~mo_vgl_date~   | ~uint64_t~               | Late modification date of Value, gradients, Laplacian of the MOs at point positions |
+  |-----------------+--------------------------+-------------------------------------------------------------------------------------|
 
 ** Data structure
 
@@ -106,7 +108,9 @@ typedef struct qmckl_mo_basis_struct {
   double * restrict coefficient_t;
 
   double * restrict mo_vgl;
+  double * restrict mo_value;
   uint64_t  mo_vgl_date;
+  uint64_t  mo_value_date;
 
   int32_t   uninitialized;
   bool      provided;
@@ -256,6 +260,33 @@ bool qmckl_mo_basis_provided(const qmckl_context context) {
 
    #+end_src
 
+*** Fortran interfaces
+
+interface
+  integer(c_int32_t) function qmckl_get_mo_basis_mo_num (context, &
+       mo_num) bind(C)
+    use, intrinsic :: iso_c_binding
+    import
+    implicit none
+    integer (c_int64_t) , intent(in)  , value :: context
+    integer (c_int64_t) , intent(out)         :: mo_num
+  end function qmckl_get_mo_basis_mo_num
+end interface
+
+interface
+  integer(c_int32_t) function qmckl_get_mo_basis_coefficient(context, &
+       coefficient, size_max) bind(C)
+    use, intrinsic :: iso_c_binding
+    import
+    implicit none
+    integer (c_int64_t) , intent(in)  , value :: context
+    double precision, intent(out)             :: coefficient(*)
+    integer (c_int64_t) , intent(int), value  :: size_max
+  end function qmckl_get_mo_basis_coefficient
+end interface
+
+    #+end_src
+
 ** Initialization functions
 
    To set the basis set, all the following functions need to be
@@ -367,7 +398,7 @@ qmckl_exit_code qmckl_finalize_mo_basis(qmckl_context context) {
   }
 
   assert (ctx->mo_basis.coefficient != NULL);
-  
+
   if (ctx->mo_basis.coefficient_t != NULL) {
     qmckl_exit_code rc = qmckl_free(context, ctx->mo_basis.coefficient);
     if (rc != QMCKL_SUCCESS) {
@@ -391,7 +422,464 @@ qmckl_exit_code qmckl_finalize_mo_basis(qmckl_context context) {
 
 * Computation
 
-** Computation of MOs
+** Computation of MOs: values only
+
+*** Get
+
+    #+begin_src c :comments org :tangle (eval h_func) :noweb yes
+qmckl_exit_code
+qmckl_get_mo_basis_mo_value(qmckl_context context,
+                            double* const mo_value,
+                            const int64_t size_max);
+    #+end_src
+
+    #+begin_src c :comments org :tangle (eval c) :noweb yes  :exports none
+qmckl_exit_code
+qmckl_get_mo_basis_mo_value(qmckl_context context,
+                            double* const mo_value,
+                            const int64_t size_max)
+{
+
+  if (qmckl_context_check(context) == QMCKL_NULL_CONTEXT) {
+    return QMCKL_NULL_CONTEXT;
+  }
+
+  qmckl_exit_code rc;
+
+  rc = qmckl_provide_ao_value(context);
+  if (rc != QMCKL_SUCCESS) return rc;
+
+  rc = qmckl_provide_mo_value(context);
+  if (rc != QMCKL_SUCCESS) return rc;
+
+  qmckl_context_struct* const ctx = (qmckl_context_struct*) context;
+  assert (ctx != NULL);
+
+  const int64_t sze = ctx->point.num * ctx->mo_basis.mo_num;
+  if (size_max < sze) {
+    return qmckl_failwith( context,
+                           QMCKL_INVALID_ARG_3,
+                           "qmckl_get_mo_basis_mo_value",
+                           "input array too small");
+  }
+  memcpy(mo_value, ctx->mo_basis.mo_value, sze * sizeof(double));
+
+  return QMCKL_SUCCESS;
+}
+    #+end_src
+
+    #+begin_src f90 :tangle (eval fh_func) :comments org :exports none
+  interface
+     integer(c_int32_t) function qmckl_get_mo_basis_mo_value (context, &
+          mo_value, size_max) bind(C)
+       use, intrinsic :: iso_c_binding
+       import
+       implicit none
+
+       integer (c_int64_t) , intent(in)  , value :: context
+       double precision,     intent(out)         :: mo_value(*)
+       integer (c_int64_t) , intent(in)  , value :: size_max
+     end function qmckl_get_mo_basis_mo_value
+  end interface
+    #+end_src
+
+    Uses the given array to compute the values.
+
+    #+begin_src c :comments org :tangle (eval h_func) :noweb yes
+qmckl_exit_code
+qmckl_get_mo_basis_mo_value_inplace (qmckl_context context,
+                                     double* const mo_value,
+                                     const int64_t size_max);
+    #+end_src
+
+    #+begin_src c :comments org :tangle (eval c) :noweb yes  :exports none
+qmckl_exit_code
+qmckl_get_mo_basis_mo_value_inplace (qmckl_context context,
+                                     double* const mo_value,
+                                     const int64_t size_max)
+{
+
+  if (qmckl_context_check(context) == QMCKL_NULL_CONTEXT) {
+    return qmckl_failwith( context,
+                           QMCKL_INVALID_CONTEXT,
+                           "qmckl_get_mo_basis_mo_value",
+                           NULL);
+  }
+
+  qmckl_exit_code rc;
+
+  qmckl_context_struct* const ctx = (qmckl_context_struct*) context;
+  assert (ctx != NULL);
+
+  const int64_t sze = ctx->mo_basis.mo_num * ctx->point.num;
+  if (size_max < sze) {
+    return qmckl_failwith( context,
+                           QMCKL_INVALID_ARG_3,
+                           "qmckl_get_mo_basis_mo_value",
+                           "input array too small");
+  }
+
+  rc = qmckl_context_touch(context);
+  if (rc != QMCKL_SUCCESS) return rc;
+
+  double* old_array = ctx->mo_basis.mo_value;
+
+  ctx->mo_basis.mo_value = mo_value;
+
+  rc = qmckl_provide_mo_value(context);
+  if (rc != QMCKL_SUCCESS) return rc;
+
+  ctx->mo_basis.mo_value = old_array;
+
+  return QMCKL_SUCCESS;
+}
+    #+end_src
+
+    #+begin_src f90 :tangle (eval fh_func) :comments org :exports none
+  interface
+     integer(c_int32_t) function qmckl_get_mo_basis_mo_value_inplace (context, &
+          mo_value, size_max) bind(C)
+       use, intrinsic :: iso_c_binding
+       import
+       implicit none
+       integer (c_int64_t) , intent(in)  , value :: context
+       double precision,     intent(out)         :: mo_value(*)
+       integer (c_int64_t) , intent(in)  , value :: size_max
+     end function qmckl_get_mo_basis_mo_value_inplace
+  end interface
+    #+end_src
+
+*** Provide
+
+    #+begin_src c :comments org :tangle (eval h_private_func) :noweb yes :exports none
+qmckl_exit_code qmckl_provide_mo_value(qmckl_context context);
+    #+end_src
+
+    #+begin_src c :comments org :tangle (eval c) :noweb yes  :exports none
+qmckl_exit_code qmckl_provide_mo_value(qmckl_context context)
+{
+
+  qmckl_exit_code rc;
+  if (qmckl_context_check(context) == QMCKL_NULL_CONTEXT) {
+    return QMCKL_NULL_CONTEXT;
+  }
+
+  qmckl_context_struct* const ctx = (qmckl_context_struct*) context;
+  assert (ctx != NULL);
+
+  if (!ctx->ao_basis.provided) {
+    return qmckl_failwith( context,
+                           QMCKL_NOT_PROVIDED,
+                           "qmckl_ao_basis",
+                           NULL);
+  }
+
+  rc = qmckl_provide_ao_value(context);
+  if (rc != QMCKL_SUCCESS) {
+    return qmckl_failwith( context,
+                           QMCKL_NOT_PROVIDED,
+                           "qmckl_ao_value",
+                           NULL);
+  }
+
+  if (!ctx->mo_basis.provided) {
+    return qmckl_failwith( context,
+                           QMCKL_NOT_PROVIDED,
+                           "qmckl_mo_basis",
+                           NULL);
+  }
+
+  /* Compute if necessary */
+  if (ctx->point.date > ctx->mo_basis.mo_value_date) {
+
+    /* Allocate array */
+    if (ctx->mo_basis.mo_value == NULL) {
+
+      qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
+      mem_info.size = ctx->point.num * ctx->mo_basis.mo_num * sizeof(double);
+      double* mo_value = (double*) qmckl_malloc(context, mem_info);
+
+      if (mo_value == NULL) {
+        return qmckl_failwith( context,
+                               QMCKL_ALLOCATION_FAILED,
+                               "qmckl_mo_basis_mo_value",
+                               NULL);
+      }
+      ctx->mo_basis.mo_value = mo_value;
+    }
+
+    if (ctx->mo_basis.mo_vgl_date == ctx->point.date) {
+
+      // mo_vgl has been computed at this step: Just copy the data.
+      
+      double * v = &(ctx->mo_basis.mo_value[0]);
+      double * vgl = &(ctx->mo_basis.mo_vgl[0]);
+      for (int i=0 ; i<ctx->point.num ; ++i) {
+        for (int k=0 ; k<ctx->mo_basis.mo_num ; ++k) {
+          v[k] = vgl[k];
+        }
+        v   += ctx->mo_basis.mo_num;
+        vgl += ctx->mo_basis.mo_num * 5;
+      }
+
+    } else {
+
+      rc = qmckl_compute_mo_basis_mo_value(context,
+                                           ctx->ao_basis.ao_num,
+                                           ctx->mo_basis.mo_num,
+                                           ctx->point.num,
+                                           ctx->mo_basis.coefficient_t,
+                                           ctx->ao_basis.ao_value,
+                                           ctx->mo_basis.mo_value);
+
+      if (rc != QMCKL_SUCCESS) {
+        return rc;
+      }
+
+    }
+
+    ctx->mo_basis.mo_value_date = ctx->date;
+  }
+
+  return QMCKL_SUCCESS;
+}
+    #+end_src
+
+*** Compute
+   :PROPERTIES:
+   :Name:     qmckl_compute_mo_basis_mo_value
+   :CRetType: qmckl_exit_code
+   :FRetType: qmckl_exit_code
+   :END:
+
+    #+NAME: qmckl_mo_basis_mo_value_args
+    | Variable            | Type                        | In/Out | Description                                     |
+    |---------------------+-----------------------------+--------+-------------------------------------------------|
+    | ~context~           | ~qmckl_context~             | in     | Global state                                    |
+    | ~ao_num~            | ~int64_t~                   | in     | Number of AOs                                   |
+    | ~mo_num~            | ~int64_t~                   | in     | Number of MOs                                   |
+    | ~point_num~         | ~int64_t~                   | in     | Number of points                                |
+    | ~coef_normalized_t~ | ~double[mo_num][ao_num]~    | in     | Transpose of the AO to MO transformation matrix |
+    | ~ao_value~          | ~double[point_num][ao_num]~ | in     | Value of the AOs                                |
+    | ~mo_value~          | ~double[point_num][mo_num]~ | out    | Value of the MOs                                |
+
+
+    The matrix of AO values is very sparse, so we use a sparse-dense
+    matrix multiplication instead of a dgemm, as exposed in
+    https://dx.doi.org/10.1007/978-3-642-38718-0_14.
+
+
+
+    #+begin_src f90 :comments org :tangle (eval f) :noweb yes
+integer function qmckl_compute_mo_basis_mo_value_doc_f(context, &
+     ao_num, mo_num, point_num, &
+     coef_normalized_t, ao_value, mo_value) &
+     result(info)
+  use qmckl
+  implicit none
+  integer(qmckl_context), intent(in)  :: context
+  integer*8             , intent(in)  :: ao_num, mo_num
+  integer*8             , intent(in)  :: point_num
+  double precision      , intent(in)  :: ao_value(ao_num,point_num)
+  double precision      , intent(in)  :: coef_normalized_t(mo_num,ao_num)
+  double precision      , intent(out) :: mo_value(mo_num,point_num)
+  integer*8 :: i,j,k
+  double precision :: c1, c2, c3, c4, c5
+
+  integer*8 :: LDA, LDB, LDC
+
+  info = QMCKL_SUCCESS
+  if (.True.)  then    ! fast algorithm
+     do j=1,point_num
+        mo_value(:,j) = 0.d0
+        do k=1,ao_num
+           if (ao_value(k,j) /= 0.d0) then
+              c1 = ao_value(k,j)
+              do i=1,mo_num
+                 mo_value(i,j) = mo_value(i,j) + coef_normalized_t(i,k) * c1
+              end do
+           end if
+        end do
+     end do
+     
+  else ! dgemm
+
+    LDA = size(coef_normalized_t,1)
+    LDB = size(ao_value,1) 
+    LDC = size(mo_value,1)
+
+    info = qmckl_dgemm(context,'N', 'N', mo_num, point_num, ao_num, 1.d0,     &
+                                    coef_normalized_t, LDA, ao_value, LDB, &
+                                    0.d0, mo_value, LDC)
+
+  end if
+
+end function qmckl_compute_mo_basis_mo_value_doc_f
+    #+end_src
+
+    #+CALL: generate_c_header(table=qmckl_mo_basis_mo_value_args,rettyp=get_value("CRetType"),fname="qmckl_compute_mo_basis_mo_value"))
+
+   #+RESULTS:
+   #+begin_src c :tangle (eval h_func) :comments org
+   qmckl_exit_code qmckl_compute_mo_basis_mo_value (
+         const qmckl_context context,
+         const int64_t ao_num,
+         const int64_t mo_num,
+         const int64_t point_num,
+         const double* coef_normalized_t,
+         const double* ao_value,
+         double* const mo_value );
+   #+end_src
+
+   #+CALL: generate_c_header(table=qmckl_mo_basis_mo_value_args,rettyp=get_value("CRetType"),fname="qmckl_compute_mo_basis_mo_value_doc"))
+
+   #+RESULTS:
+   #+begin_src c :tangle (eval h_func) :comments org
+   qmckl_exit_code qmckl_compute_mo_basis_mo_value_doc (
+         const qmckl_context context,
+         const int64_t ao_num,
+         const int64_t mo_num,
+         const int64_t point_num,
+         const double* coef_normalized_t,
+         const double* ao_value,
+         double* const mo_value );
+   #+end_src
+
+   #+CALL: generate_c_interface(table=qmckl_mo_basis_mo_value_args,rettyp=get_value("CRetType"),fname="qmckl_compute_mo_basis_mo_value_doc"))
+
+    #+RESULTS:
+    #+begin_src f90 :tangle (eval f) :comments org :exports none
+    integer(c_int32_t) function qmckl_compute_mo_basis_mo_value_doc &
+        (context, ao_num, mo_num, point_num, coef_normalized_t, ao_value, mo_value) &
+        bind(C) result(info)
+
+      use, intrinsic :: iso_c_binding
+      implicit none
+
+      integer (c_int64_t) , intent(in)  , value :: context
+      integer (c_int64_t) , intent(in)  , value :: ao_num
+      integer (c_int64_t) , intent(in)  , value :: mo_num
+      integer (c_int64_t) , intent(in)  , value :: point_num
+      real    (c_double ) , intent(in)          :: coef_normalized_t(ao_num,mo_num)
+      real    (c_double ) , intent(in)          :: ao_value(ao_num,point_num)
+      real    (c_double ) , intent(out)         :: mo_value(mo_num,point_num)
+
+      integer(c_int32_t), external :: qmckl_compute_mo_basis_mo_value_doc_f
+      info = qmckl_compute_mo_basis_mo_value_doc_f &
+             (context, ao_num, mo_num, point_num, coef_normalized_t, ao_value, mo_value)
+
+    end function qmckl_compute_mo_basis_mo_value_doc
+    #+end_src
+
+    #+begin_src c :tangle (eval c) :comments org
+qmckl_exit_code
+qmckl_compute_mo_basis_mo_value (const qmckl_context context,
+                                 const int64_t ao_num,
+                                 const int64_t mo_num,
+                                 const int64_t point_num,
+                                 const double* coef_normalized_t,
+                                 const double* ao_value,
+                                 double* const mo_value )
+{
+#ifdef HAVE_HPC
+  return qmckl_compute_mo_basis_mo_value_hpc (context, ao_num, mo_num, point_num, coef_normalized_t, ao_value, mo_value);
+#else
+  return qmckl_compute_mo_basis_mo_value_doc (context, ao_num, mo_num, point_num, coef_normalized_t, ao_value, mo_value);
+#endif
+}
+    #+end_src
+
+*** HPC version
+
+
+    #+begin_src c :tangle (eval h_func) :comments org
+#ifdef HAVE_HPC
+qmckl_exit_code
+qmckl_compute_mo_basis_mo_value_hpc (const qmckl_context context,
+                                     const int64_t ao_num,
+                                     const int64_t mo_num,
+                                     const int64_t point_num,
+                                     const double* coef_normalized_t,
+                                     const double* ao_value,
+                                     double* const mo_value );
+#endif
+    #+end_src
+
+    #+begin_src c :tangle (eval c) :comments org
+#ifdef HAVE_HPC
+qmckl_exit_code
+qmckl_compute_mo_basis_mo_value_hpc (const qmckl_context context,
+                                     const int64_t ao_num,
+                                     const int64_t mo_num,
+                                     const int64_t point_num,
+                                     const double* restrict coef_normalized_t,
+                                     const double* restrict ao_value,
+                                     double* restrict const mo_value )
+{
+  assert (context != QMCKL_NULL_CONTEXT);
+
+#ifdef HAVE_OPENMP
+  #pragma omp parallel for
+#endif
+  for (int64_t ipoint=0 ; ipoint < point_num ; ++ipoint) {
+    double* restrict const vgl1  = &(mo_value[ipoint*mo_num]);
+    const double* restrict avgl1 = &(ao_value[ipoint*ao_num]);
+
+    for (int64_t i=0 ; i<mo_num ; ++i) {
+      vgl1[i] = 0.;
+    }
+
+    int64_t nidx=0;
+    int64_t idx[ao_num];
+    double  av1[ao_num];
+    for (int64_t k=0 ; k<ao_num ; ++k) {
+      if (avgl1[k] != 0.) {
+        idx[nidx] = k;
+        av1[nidx] = avgl1[k];
+        ++nidx;
+      }
+    }
+
+    int64_t n;
+
+    for (n=0 ; n < nidx-4 ; n+=4) {
+      const double* restrict ck1 = coef_normalized_t + idx[n  ]*mo_num;
+      const double* restrict ck2 = coef_normalized_t + idx[n+1]*mo_num;
+      const double* restrict ck3 = coef_normalized_t + idx[n+2]*mo_num;
+      const double* restrict ck4 = coef_normalized_t + idx[n+3]*mo_num;
+
+      const double a11 = av1[n  ];
+      const double a21 = av1[n+1];
+      const double a31 = av1[n+2];
+      const double a41 = av1[n+3];
+
+#ifdef HAVE_OPENMP
+#pragma omp simd
+#endif
+      for (int64_t i=0 ; i<mo_num ; ++i) {
+        vgl1[i] = vgl1[i] + ck1[i] * a11 + ck2[i] * a21 + ck3[i] * a31 + ck4[i] * a41;
+      }
+    }
+
+    const int64_t n0 = n < 0 ? 0 : n;
+    for (int64_t m=n0 ; m < nidx ; m+=1) {
+      const double* restrict ck = coef_normalized_t + idx[m]*mo_num;
+      const double a1 = av1[m];
+
+#ifdef HAVE_OPENMP
+  #pragma omp simd
+#endif
+      for (int64_t i=0 ; i<mo_num ; ++i) {
+        vgl1[i] += ck[i] * a1;
+      }
+    }
+  }
+  return QMCKL_SUCCESS;
+}
+#endif
+    #+end_src
+
+** Computation of MOs: values, gradient, Laplacian
 
 *** Get
 
@@ -444,7 +932,7 @@ qmckl_get_mo_basis_mo_vgl(qmckl_context context,
        use, intrinsic :: iso_c_binding
        import
        implicit none
-       
+
        integer (c_int64_t) , intent(in)  , value :: context
        double precision,     intent(out)         :: mo_vgl(*)
        integer (c_int64_t) , intent(in)  , value :: size_max
@@ -618,8 +1106,8 @@ qmckl_exit_code qmckl_provide_mo_vgl(qmckl_context context)
     matrix multiplication instead of a dgemm, as exposed in
     https://dx.doi.org/10.1007/978-3-642-38718-0_14.
 
-    
-    
+
+
     #+begin_src f90 :comments org :tangle (eval f) :noweb yes
 integer function qmckl_compute_mo_basis_mo_vgl_doc_f(context, &
      ao_num, mo_num, point_num, &
@@ -636,25 +1124,41 @@ integer function qmckl_compute_mo_basis_mo_vgl_doc_f(context, &
   integer*8 :: i,j,k
   double precision :: c1, c2, c3, c4, c5
 
-  do j=1,point_num
-     mo_vgl(:,:,j) = 0.d0
-     do k=1,ao_num
-        if (ao_vgl(k,1,j) /= 0.d0) then
-           c1 = ao_vgl(k,1,j)
-           c2 = ao_vgl(k,2,j)
-           c3 = ao_vgl(k,3,j)
-           c4 = ao_vgl(k,4,j)
-           c5 = ao_vgl(k,5,j)
-           do i=1,mo_num
-              mo_vgl(i,1,j) = mo_vgl(i,1,j) + coef_normalized_t(i,k) * c1
-              mo_vgl(i,2,j) = mo_vgl(i,2,j) + coef_normalized_t(i,k) * c2
-              mo_vgl(i,3,j) = mo_vgl(i,3,j) + coef_normalized_t(i,k) * c3
-              mo_vgl(i,4,j) = mo_vgl(i,4,j) + coef_normalized_t(i,k) * c4
-              mo_vgl(i,5,j) = mo_vgl(i,5,j) + coef_normalized_t(i,k) * c5
-           end do
-        end if
+  integer*8 :: LDA, LDB, LDC
+
+  info = QMCKL_SUCCESS
+  if (.True.)  then    ! fast algorithm
+     do j=1,point_num
+        mo_vgl(:,:,j) = 0.d0
+        do k=1,ao_num
+           if (ao_vgl(k,1,j) /= 0.d0) then
+              c1 = ao_vgl(k,1,j)
+              c2 = ao_vgl(k,2,j)
+              c3 = ao_vgl(k,3,j)
+              c4 = ao_vgl(k,4,j)
+              c5 = ao_vgl(k,5,j)
+              do i=1,mo_num
+                 mo_vgl(i,1,j) = mo_vgl(i,1,j) + coef_normalized_t(i,k) * c1
+                 mo_vgl(i,2,j) = mo_vgl(i,2,j) + coef_normalized_t(i,k) * c2
+                 mo_vgl(i,3,j) = mo_vgl(i,3,j) + coef_normalized_t(i,k) * c3
+                 mo_vgl(i,4,j) = mo_vgl(i,4,j) + coef_normalized_t(i,k) * c4
+                 mo_vgl(i,5,j) = mo_vgl(i,5,j) + coef_normalized_t(i,k) * c5
+              end do
+           end if
+        end do
      end do
-  end do
+     
+  else ! dgemm
+
+    LDA = size(coef_normalized_t,1)
+    LDB = size(ao_vgl,1) 
+    LDC = size(mo_vgl,1)
+
+    info = qmckl_dgemm(context,'N', 'N', mo_num, point_num*5_8, ao_num*1_8, 1.d0,     &
+                                    coef_normalized_t, LDA, ao_vgl, LDB, &
+                                    0.d0, mo_vgl, LDC)
+
+  end if
 
 end function qmckl_compute_mo_basis_mo_vgl_doc_f
     #+end_src
@@ -670,7 +1174,7 @@ end function qmckl_compute_mo_basis_mo_vgl_doc_f
          const int64_t point_num,
          const double* coef_normalized_t,
          const double* ao_vgl,
-         double* const mo_vgl ); 
+         double* const mo_vgl );
    #+end_src
 
    #+CALL: generate_c_header(table=qmckl_mo_basis_mo_vgl_args,rettyp=get_value("CRetType"),fname="qmckl_compute_mo_basis_mo_vgl_doc"))
@@ -684,11 +1188,11 @@ end function qmckl_compute_mo_basis_mo_vgl_doc_f
          const int64_t point_num,
          const double* coef_normalized_t,
          const double* ao_vgl,
-         double* const mo_vgl ); 
+         double* const mo_vgl );
    #+end_src
 
    #+CALL: generate_c_interface(table=qmckl_mo_basis_mo_vgl_args,rettyp=get_value("CRetType"),fname="qmckl_compute_mo_basis_mo_vgl_doc"))
-   
+
     #+RESULTS:
     #+begin_src f90 :tangle (eval f) :comments org :exports none
     integer(c_int32_t) function qmckl_compute_mo_basis_mo_vgl_doc &
@@ -713,7 +1217,7 @@ end function qmckl_compute_mo_basis_mo_vgl_doc_f
     end function qmckl_compute_mo_basis_mo_vgl_doc
     #+end_src
 
-    #+begin_src c :tangle (eval c) :comments org                                                                             
+    #+begin_src c :tangle (eval c) :comments org
 qmckl_exit_code
 qmckl_compute_mo_basis_mo_vgl (const qmckl_context context,
                             const int64_t ao_num,
@@ -730,12 +1234,11 @@ qmckl_compute_mo_basis_mo_vgl (const qmckl_context context,
 #endif
 }
     #+end_src
-    
-    
-*** HPC version
-    
 
-    #+begin_src c :tangle (eval h_func) :comments org                                                                             
+*** HPC version
+
+
+    #+begin_src c :tangle (eval h_func) :comments org
 #ifdef HAVE_HPC
 qmckl_exit_code
 qmckl_compute_mo_basis_mo_vgl_hpc (const qmckl_context context,
@@ -748,7 +1251,7 @@ qmckl_compute_mo_basis_mo_vgl_hpc (const qmckl_context context,
 #endif
     #+end_src
 
-    #+begin_src c :tangle (eval c) :comments org                                                                             
+    #+begin_src c :tangle (eval c) :comments org
 #ifdef HAVE_HPC
 qmckl_exit_code
 qmckl_compute_mo_basis_mo_vgl_hpc (const qmckl_context context,
@@ -759,16 +1262,19 @@ qmckl_compute_mo_basis_mo_vgl_hpc (const qmckl_context context,
                                    const double* restrict ao_vgl,
                                    double* restrict const mo_vgl )
 {
+  assert (context != QMCKL_NULL_CONTEXT);
+
 #ifdef HAVE_OPENMP
   #pragma omp parallel for
 #endif
   for (int64_t ipoint=0 ; ipoint < point_num ; ++ipoint) {
     double* restrict const vgl1 = &(mo_vgl[ipoint*5*mo_num]);
-    const double* restrict avgl1 = &(ao_vgl[ipoint*5*ao_num]);
     double* restrict const vgl2 =  vgl1 + mo_num;
     double* restrict const vgl3 =  vgl1 + (mo_num << 1);
     double* restrict const vgl4 =  vgl1 + (mo_num << 1) + mo_num;
     double* restrict const vgl5 =  vgl1 + (mo_num << 2);
+
+    const double* restrict avgl1 = &(ao_vgl[ipoint*5*ao_num]);
     const double* restrict avgl2 = avgl1 + ao_num;
     const double* restrict avgl3 = avgl1 + (ao_num << 1);
     const double* restrict avgl4 = avgl1 + (ao_num << 1) + ao_num;
@@ -790,7 +1296,6 @@ qmckl_compute_mo_basis_mo_vgl_hpc (const qmckl_context context,
     double  av4[ao_num];
     double  av5[ao_num];
     for (int64_t k=0 ; k<ao_num ; ++k) {
-      const double* restrict ck1 = coef_normalized_t + k*mo_num;
       if (avgl1[k] != 0.) {
         idx[nidx] = k;
         av1[nidx] = avgl1[k];
@@ -803,8 +1308,8 @@ qmckl_compute_mo_basis_mo_vgl_hpc (const qmckl_context context,
     }
 
     int64_t n;
+
     for (n=0 ; n < nidx-4 ; n+=4) {
-      int64_t k = idx[n];
       const double* restrict ck1 = coef_normalized_t + idx[n  ]*mo_num;
       const double* restrict ck2 = coef_normalized_t + idx[n+1]*mo_num;
       const double* restrict ck3 = coef_normalized_t + idx[n+2]*mo_num;
@@ -814,22 +1319,22 @@ qmckl_compute_mo_basis_mo_vgl_hpc (const qmckl_context context,
       const double a21 = av1[n+1];
       const double a31 = av1[n+2];
       const double a41 = av1[n+3];
-      
+
       const double a12 = av2[n  ];
       const double a22 = av2[n+1];
       const double a32 = av2[n+2];
       const double a42 = av2[n+3];
-      
+
       const double a13 = av3[n  ];
       const double a23 = av3[n+1];
       const double a33 = av3[n+2];
       const double a43 = av3[n+3];
-      
+
       const double a14 = av4[n  ];
       const double a24 = av4[n+1];
       const double a34 = av4[n+2];
       const double a44 = av4[n+3];
-      
+
       const double a15 = av5[n  ];
       const double a25 = av5[n+1];
       const double a35 = av5[n+2];
@@ -847,8 +1352,7 @@ qmckl_compute_mo_basis_mo_vgl_hpc (const qmckl_context context,
       }
     }
 
-    int64_t n0 = nidx-4;
-    n0 = n0 < 0 ? 0 : n0;
+    const int64_t n0 = n < 0 ? 0 : n;
     for (int64_t m=n0 ; m < nidx ; m+=1) {
       const double* restrict ck = coef_normalized_t + idx[m]*mo_num;
       const double a1 = av1[m];
@@ -874,9 +1378,9 @@ qmckl_compute_mo_basis_mo_vgl_hpc (const qmckl_context context,
 #endif
     #+end_src
 
-*** Test
+** Test
 
-    #+begin_src python :results output :exports none
+   #+begin_src python :results output :exports none
 import numpy as np
 
 def f(a,x,y):
@@ -936,9 +1440,9 @@ print ( "[2][1][15][14] : %25.15e"% df(a,x,y,2))
 print ( "[3][1][15][14] : %25.15e"% df(a,x,y,3))
 print ( "[4][1][15][14] : %25.15e"% lf(a,x,y))
 
-    #+end_src
+   #+end_src
 
-     #+begin_src c :tangle (eval c_test) :exports none
+    #+begin_src c :tangle (eval c_test) :exports none
 {
 #define walk_num chbrclf_walk_num
 #define elec_num chbrclf_elec_num
@@ -1063,9 +1567,35 @@ assert (rc == QMCKL_SUCCESS);
 
 assert(qmckl_mo_basis_provided(context));
 
+rc = qmckl_context_touch(context);
+assert (rc == QMCKL_SUCCESS);
+
+double mo_value[walk_num*elec_num][chbrclf_mo_num];
+rc = qmckl_get_mo_basis_mo_value(context, &(mo_value[0][0]), walk_num*elec_num*chbrclf_mo_num);
+assert (rc == QMCKL_SUCCESS);
+
 double mo_vgl[walk_num*elec_num][5][chbrclf_mo_num];
 rc = qmckl_get_mo_basis_mo_vgl(context, &(mo_vgl[0][0][0]), walk_num*elec_num*5*chbrclf_mo_num);
 assert (rc == QMCKL_SUCCESS);
+
+for (int i=0 ; i< walk_num*elec_num; ++i) {
+  for (int k=0 ; k< chbrclf_mo_num ; ++k) {
+    assert(fabs(mo_vgl[i][0][k] - mo_value[i][k]) < 1.e-12) ;
+  }
+ }
+
+rc = qmckl_context_touch(context);
+assert (rc == QMCKL_SUCCESS);
+ 
+rc = qmckl_get_mo_basis_mo_value(context, &(mo_value[0][0]), walk_num*elec_num*chbrclf_mo_num);
+assert (rc == QMCKL_SUCCESS);
+
+for (int i=0 ; i< walk_num*elec_num; ++i) {
+  for (int k=0 ; k< chbrclf_mo_num ; ++k) {
+    assert(fabs(mo_vgl[i][0][k] - mo_value[i][k]) < 1.e-12) ;
+  }
+ }
+
 
 // Test overlap of MO
 //double point_x[10];
@@ -1124,7 +1654,7 @@ printf(" mo_vgl mo_vgl[1][26][224] %25.15e\n", mo_vgl[2][1][3]);
 printf("\n");
 }
 
-     #+end_src
+    #+end_src
 
 * End of files                                                     :noexport:
 

--- a/org/qmckl_numprec.org
+++ b/org/qmckl_numprec.org
@@ -250,19 +250,19 @@ qmckl_exit_code qmckl_set_numprec_range(const qmckl_context context, const int r
    # Fortran interface
    #+begin_src f90 :tangle (eval fh_func)
   interface
-     integer (qmckl_exit_code) function qmckl_numprec_set_range(context, range) bind(C)
+     integer (qmckl_exit_code) function qmckl_set_numprec_range(context, range) bind(C)
        use, intrinsic :: iso_c_binding
        import
        integer (qmckl_context), intent(in), value :: context
        integer (c_int32_t), intent(in), value :: range
-     end function qmckl_numprec_set_range
+     end function qmckl_set_numprec_range
   end interface
    #+end_src
 
    ~qmckl_get_numprec_range~ returns the value of the numerical range in the context.
 
   #+begin_src c :comments org :tangle (eval h_func) :exports none
-int32_t qmckl_get_numprec_get_range(const qmckl_context context);
+int32_t qmckl_get_numprec_range(const qmckl_context context);
   #+end_src
 
   # Source


### PR DESCRIPTION
* compute_cord_vect_full done

* Replace placeholder cuBLAS kernels with new C HPC implementation

* Fix info

* Simplified configure

* Fix configure

* Fixed configure.ac for GPUs

* Fix flags

* Fix OpenACC

* Start implementing cublas

* Fix openacc

* Improve configure

* qmckl_compute_een_rescaled_e_hpc (c version)  working

* debugging factor_ee_deriv_e

* Add openmp and cublas

* Cleaning

* Ok for openmp and Cublas

* Fix CI

* OpenMP

* First working OpenMP version

* Fix build

* Fix OpenACC and OpenMP implementations

* test passed

* removed unused variable in doc and hpc of compute_factor_ee_deriv_e

* Fix cublas

* Add cublas batched

* Changed enable-cublas into with-cublas

* Add cublas batch Dgemm

* Configure cuBLAS with --enable-gpu and clean code

* Revert cuBLAS to old config

* Add Fortran interfaces in MOs

* Add Fortran interfaces in MOs

* Fix previous commit

* Fix typos in function names

* Restored dgemm for AO to MO in doc version

* Fixed mo bug

* Fixed cppcheck

* Fix bad style

* Fixed cppcheck

* warnings

* Fixed bug in AO HPC

* Possibility to compute only values

Co-authored-by: Gianfranco Abrusci <abrusci.gianfranco@gmail.com>
Co-authored-by: Anthony Scemama <scemama@irsamc.ups-tlse.fr>
Co-authored-by: 2323 <p22001sa@olympelogin1.bullx>
Co-authored-by: 2323 <p22001sa@olympevolta0.bullx>
Co-authored-by: 2323 <p22001sa@olympelogin2.bullx>
Co-authored-by: hoffer <max.hofferlormand@hotmail.fr>
Co-authored-by: q-posev <posenitskiy@irsamc.ups-tlse.fr>